### PR TITLE
fix: MD表示崩れ修正 & Google Drive認証永続化

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -338,6 +338,10 @@ body {
   border-radius: var(--radius-lg);
   padding: var(--spacing-xl);
   box-shadow: var(--shadow-md);
+  /* 長いURLの折り返し対応 */
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 /* Markdown Typography */
@@ -388,6 +392,7 @@ body {
   text-decoration: none;
   border-bottom: 1px solid transparent;
   transition: border-color var(--transition-fast);
+  word-break: break-all;
 }
 
 .markdown-content a:hover {
@@ -685,6 +690,33 @@ body {
 }
 
 .search-close-button svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* ============================================
+   Search Logout Button
+   ============================================ */
+.search-logout-button {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.search-logout-button:hover {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--color-error);
+}
+
+.search-logout-button svg {
   width: 18px;
   height: 18px;
 }

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -23,6 +23,7 @@ export function SearchPanel({ isOpen, onClose, onFileSelect }: SearchPanelProps)
     results,
     search,
     authenticate,
+    logout,
     fetchFileContent,
     clearResults,
   } = useGoogleDriveSearch();
@@ -145,6 +146,15 @@ export function SearchPanel({ isOpen, onClose, onFileSelect }: SearchPanelProps)
             />
             {isLoading && <div className="search-spinner" />}
           </div>
+          {isAuthenticated && (
+            <button className="search-logout-button" onClick={logout} title="ログアウト">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+            </button>
+          )}
           <button className="search-close-button" onClick={handleClose}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M18 6L6 18M6 6l12 12" />


### PR DESCRIPTION
## Summary

- 長いURLがMarkdownプレビューでコンテナを突き抜ける問題を修正
- Google Drive認証トークンをlocalStorageに保存し、ページリロード後も再認証を不要に
- 明示的なログアウト機能を追加（検索パネル内にボタン配置）

## Changes

### URLの表示崩れ修正 (`App.css`)
- `.markdown-content` に `overflow-wrap`, `word-wrap`, `word-break` を追加
- リンク要素に `word-break: break-all` を適用

### Google Drive認証の永続化 (`useGoogleDriveSearch.ts`)
- 認証成功時にトークンと有効期限を localStorage に保存
- 初期化時に既存トークンを復元（有効期限5分前に自動失効）
- `logout()` 関数を追加

### ログアウトUI (`SearchPanel.tsx`, `App.css`)
- 認証済み状態で検索ヘッダーにログアウトボタンを表示

## Test plan

- [ ] 長いURLを含むMarkdownファイルを表示し、正しく折り返されることを確認
- [ ] 認証後にページをリロードし、再認証なしで検索できることを確認
- [ ] ログアウトボタンをクリックし、認証状態がクリアされることを確認
- [ ] ログアウト後、再度認証できることを確認