### PR TITLE
fix: React Strict Mode でのスクリプトロード競合を修正

### DIFF
--- a/src/utils/loadScript.ts
+++ b/src/utils/loadScript.ts
@@ -1,15 +1,62 @@
 /**
  * スクリプトを動的に読み込むヘルパー関数
  * 同じスクリプトが複数回読み込まれるのを防ぐ
+ * React Strict Mode での二重実行にも対応
  */
+
+// ロード中/ロード済みのスクリプトを追跡するMap
+const scriptPromises = new Map<string, Promise<void>>();
+
+/**
+ * Google API スクリプトがロード済みかどうかをグローバル変数で確認
+ */
+function isScriptLoaded(src: string): boolean {
+  if (src.includes('apis.google.com/js/api.js')) {
+    return typeof window.gapi !== 'undefined';
+  }
+  if (src.includes('accounts.google.com/gsi/client')) {
+    return typeof window.google !== 'undefined' && typeof window.google.accounts !== 'undefined';
+  }
+  return false;
+}
+
 export function loadScript(src: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    // すでに読み込まれている場合はスキップ
-    if (document.querySelector(`script[src="${src}"]`)) {
-      resolve();
+  // 既にロード完了している場合（グローバル変数で確認）
+  if (isScriptLoaded(src)) {
+    return Promise.resolve();
+  }
+
+  // 既にロード中の場合は同じPromiseを返す
+  const existingPromise = scriptPromises.get(src);
+  if (existingPromise) {
+    return existingPromise;
+  }
+
+  // 新しくロードを開始
+  const promise = new Promise<void>((resolve, reject) => {
+    // 既にDOMに存在するスクリプトタグを確認
+    const existingScript = document.querySelector(`script[src="${src}"]`) as HTMLScriptElement | null;
+    
+    if (existingScript) {
+      // スクリプトが既にロード済みかチェック（グローバル変数で確認）
+      if (isScriptLoaded(src)) {
+        resolve();
+        return;
+      }
+      
+      // まだロード中の場合、ポーリングで完了を待つ
+      const checkLoaded = () => {
+        if (isScriptLoaded(src)) {
+          resolve();
+        } else {
+          setTimeout(checkLoaded, 50);
+        }
+      };
+      checkLoaded();
       return;
     }
 
+    // 新しくスクリプトを追加
     const script = document.createElement('script');
     script.src = src;
     script.async = true;
@@ -18,4 +65,7 @@ export function loadScript(src: string): Promise<void> {
     script.onerror = () => reject(new Error(`Failed to load script: ${src}`));
     document.head.appendChild(script);
   });
+
+  scriptPromises.set(src, promise);
+  return promise;
 }


### PR DESCRIPTION
## Summary

- React Strict Mode の二重実行で「Failed to load Google APIs」エラーが発生する問題を修正
- `loadScript` 関数を改善し、スクリプトロードの競合状態を解消

## Changes

### `loadScript.ts`

1. **グローバル変数チェック**: `window.gapi` / `window.google.accounts` でロード完了を確認
2. **Promise共有**: 同じスクリプトへの複数リクエストに同一Promiseを返す
3. **ポーリング待機**: DOMにスクリプトが存在するがロード中の場合、50msごとにチェック

## Root Cause

React 18 の Strict Mode では `useEffect` が2回実行される。
1回目でスクリプトタグがDOMに追加され、2回目では「既に存在する」と判断して即 resolve していたが、スクリプトはまだロード中だった。

## Test plan

- [ ] ブラウザをリロードし、「Failed to load Google APIs」エラーが出ないことを確認
- [ ] Google Drive 認証が正常に動作することを確認
- [ ] ファイル検索・選択が正常に動作することを確認