### PR TITLE
fix: ログアウト時にGoogleトークンをrevokeしてアカウント切り替えを可能に

### DIFF
--- a/src/hooks/useGoogleDriveSearch.ts
+++ b/src/hooks/useGoogleDriveSearch.ts
@@ -167,8 +167,14 @@ export function useGoogleDriveSearch(): UseGoogleDriveSearchReturn {
     }
   }, [isApiLoaded]);
 
-  // ログアウト（トークンをクリア）
+  // ログアウト（トークンをクリア & revoke）
   const logout = useCallback(() => {
+    // Google のトークンを revoke（次回認証時にアカウント選択画面を表示させる）
+    if (accessTokenRef.current && window.google?.accounts?.oauth2?.revoke) {
+      window.google.accounts.oauth2.revoke(accessTokenRef.current, () => {
+        console.log('Google token revoked');
+      });
+    }
     accessTokenRef.current = null;
     setIsAuthenticated(false);
     setResults([]);

--- a/src/types/google.d.ts
+++ b/src/types/google.d.ts
@@ -23,6 +23,7 @@ declare namespace google {
       }
 
       function initTokenClient(config: TokenClientConfig): TokenClient;
+      function revoke(token: string, callback?: () => void): void;
     }
   }
 


### PR DESCRIPTION
## Summary

- ログアウト後に別のGoogleアカウントでログインできない問題を修正
- ログアウト時に `google.accounts.oauth2.revoke()` でトークンを無効化

## Changes

### `useGoogleDriveSearch.ts`
- `logout` 関数でトークンをrevokeするよう修正

### `google.d.ts`
- `revoke` 関数の型定義を追加

## Root Cause

`requestAccessToken({ prompt: '' })` はブラウザにキャッシュされたGoogleセッションを自動的に再利用するため、ログアウトしてもアカウント選択画面が表示されなかった。

## Test plan

- [ ] ログアウトボタンをクリック
- [ ] 認証ボタンをクリックし、アカウント選択画面が表示されることを確認
- [ ] 別のGoogleアカウントでログインできることを確認