### PR TITLE
Fix filename wrapping for long filenames

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -323,8 +323,12 @@ body {
   color: var(--color-accent);
   font-weight: 500;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--spacing-sm);
+  /* 長いファイル名の折り返し対応 */
+  word-break: break-word;
+  overflow-wrap: break-word;
+  line-height: 1.4;
 }
 
 .file-title::before {


### PR DESCRIPTION
## Summary

- Fix long filenames not wrapping on mobile devices
- Update `.file-title` CSS to allow word breaking and overflow wrapping

## Test plan

- [ ] Open a file with a long filename (e.g., `関係者間スキーム整理：法規制・契約関係・資金フローの包括的分析2e4c5579d2b8807789a1f60ac2adffd7.md`)
- [ ] Verify the filename wraps properly on narrow screens