### PR TITLE
Add close file functionality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -316,6 +316,10 @@ body {
   margin-bottom: var(--spacing-lg);
   padding-bottom: var(--spacing-md);
   border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
 }
 
 .file-title {
@@ -323,8 +327,34 @@ body {
   color: var(--color-accent);
   font-weight: 500;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--spacing-sm);
+}
+
+.close-file-button {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.close-file-button:hover {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: rgba(248, 113, 113, 0.5);
+  color: var(--color-error);
+}
+
+.close-file-button svg {
+  width: 18px;
+  height: 18px;
 }
 
 .file-title::before {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,12 @@ function App() {
     setFileHistory([]);
   }, []);
 
+  // ファイルを閉じる
+  const handleCloseFile = useCallback(() => {
+    setMarkdownContent(null);
+    setFileName(null);
+  }, []);
+
   // Ctrl/Cmd + K で検索パネルを開く
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -210,7 +216,11 @@ function App() {
 
       <main className="app-main">
         {markdownContent ? (
-          <MarkdownViewer content={markdownContent} fileName={fileName || undefined} />
+          <MarkdownViewer 
+            content={markdownContent} 
+            fileName={fileName || undefined}
+            onClose={handleCloseFile}
+          />
         ) : (
           <div className="empty-state">
             <div className="empty-icon">📂</div>

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -7,9 +7,10 @@ import type { Components } from 'react-markdown';
 interface MarkdownViewerProps {
   content: string;
   fileName?: string;
+  onClose?: () => void;
 }
 
-export function MarkdownViewer({ content, fileName }: MarkdownViewerProps) {
+export function MarkdownViewer({ content, fileName, onClose }: MarkdownViewerProps) {
   const components: Components = {
     code({ className, children, ...props }) {
       const match = /language-(\w+)/.exec(className || '');
@@ -66,6 +67,13 @@ export function MarkdownViewer({ content, fileName }: MarkdownViewerProps) {
       {fileName && (
         <div className="viewer-header">
           <h2 className="file-title">{fileName}</h2>
+          {onClose && (
+            <button className="close-file-button" onClick={onClose} title="ファイルを閉じる">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 6L6 18M6 6l12 12" />
+              </svg>
+            </button>
+          )}
         </div>
       )}
       <article className="markdown-content">


### PR DESCRIPTION
## Summary

- Add close button (X icon) next to the filename header
- Allow users to dismiss the currently opened file and return to empty state
- Button styled with hover effect (red highlight)

## Test plan

- [ ] Open a markdown file
- [ ] Click the X button next to the filename
- [ ] Verify the file is closed and the empty state is displayed