### PR TITLE
Fix Markuplint h1 requirement error

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      <h1>MD Viewer</h1>
+      <p>This application requires JavaScript to run.</p>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Add `<noscript>` element with `<h1>` heading to satisfy Markuplint accessibility rule
- Provides fallback content for users with JavaScript disabled

## Test plan

- [ ] Verify Markuplint no longer shows "要素「h1」が必要です" error
- [ ] Verify app still works normally