### PR TITLE
Fix auth state sharing between components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [fileHistory, setFileHistory] = useState<FileHistoryItem[]>([]);
 
-  // Google Drive Search フック
+  // Google Drive Search フック（状態を一元管理）
   const { 
     fetchFileContent, 
     userInfo, 
@@ -78,6 +78,11 @@ function App() {
     isApiLoaded,
     authenticate,
     logout,
+    search,
+    isLoading,
+    results,
+    error,
+    clearResults,
   } = useGoogleDriveSearch();
 
   // 環境変数チェック
@@ -239,6 +244,15 @@ function App() {
         isOpen={isSearchOpen}
         onClose={() => setIsSearchOpen(false)}
         onFileSelect={handleSearchFileSelect}
+        isApiLoaded={isApiLoaded}
+        isAuthenticated={isAuthenticated}
+        authenticate={authenticate}
+        search={search}
+        fetchFileContent={fetchFileContent}
+        isLoading={isLoading}
+        results={results}
+        error={error}
+        clearResults={clearResults}
       />
     </div>
   );

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -1,32 +1,41 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { useGoogleDriveSearch } from '../hooks/useGoogleDriveSearch';
 import { SearchResults } from './SearchResults';
 
 interface SearchPanelProps {
   isOpen: boolean;
   onClose: () => void;
   onFileSelect: (file: DriveFile, content: string) => void;
+  // 認証関連のprops（App.tsxから受け取る）
+  isApiLoaded: boolean;
+  isAuthenticated: boolean;
+  authenticate: () => void;
+  search: (query: string) => Promise<void>;
+  fetchFileContent: (fileId: string, signal?: AbortSignal) => Promise<string | null>;
+  isLoading: boolean;
+  results: DriveFile[];
+  error: string | null;
+  clearResults: () => void;
 }
 
-export function SearchPanel({ isOpen, onClose, onFileSelect }: SearchPanelProps) {
+export function SearchPanel({
+  isOpen,
+  onClose,
+  onFileSelect,
+  isApiLoaded,
+  isAuthenticated,
+  authenticate,
+  search,
+  fetchFileContent,
+  isLoading,
+  results,
+  error,
+  clearResults,
+}: SearchPanelProps) {
   const [query, setQuery] = useState('');
   const [isLoadingContent, setIsLoadingContent] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-
-  const {
-    isLoading,
-    isApiLoaded,
-    isAuthenticated,
-    error,
-    results,
-    search,
-    authenticate,
-    logout,
-    fetchFileContent,
-    clearResults,
-  } = useGoogleDriveSearch();
 
   // パネルが開いたときにフォーカス
   useEffect(() => {
@@ -146,15 +155,6 @@ export function SearchPanel({ isOpen, onClose, onFileSelect }: SearchPanelProps)
             />
             {isLoading && <div className="search-spinner" />}
           </div>
-          {isAuthenticated && (
-            <button className="search-logout-button" onClick={logout} title="ログアウト">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-                <polyline points="16 17 21 12 16 7" />
-                <line x1="21" y1="12" x2="9" y2="12" />
-              </svg>
-            </button>
-          )}
           <button className="search-close-button" onClick={handleClose}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M18 6L6 18M6 6l12 12" />


### PR DESCRIPTION
## Summary

- Remove `useGoogleDriveSearch` call from SearchPanel (was causing duplicate state)
- Pass auth-related state from App.tsx to SearchPanel via props
- This ensures FABMenu and SearchPanel share the same auth state instance
- Remove redundant logout button from SearchPanel (use FABMenu for logout instead)

## Problem

FABMenu showed user as logged in, but SearchPanel showed login prompt because they were using separate hook instances with independent state.

## Solution

Centralize `useGoogleDriveSearch` hook call in App.tsx and pass state down to SearchPanel via props.

## Test plan

- [ ] Login via FABMenu
- [ ] Open SearchPanel - should show search input (not login prompt)
- [ ] Logout via FABMenu
- [ ] Open SearchPanel - should show login prompt