### PR TITLE
Add local file picker for opening Markdown files from device

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1410,6 +1410,52 @@ body {
   height: 20px;
 }
 
+/* Login Divider */
+.login-divider {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 280px;
+  gap: var(--spacing-md);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.login-divider::before,
+.login-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
+/* Local File Button */
+.local-file-button {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: transparent;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.local-file-button:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-border-light);
+}
+
+.local-file-button svg {
+  width: 20px;
+  height: 20px;
+  color: var(--color-text-secondary);
+}
+
 /* Search Prompt (Logged In) */
 .search-prompt {
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { SearchPanel } from './components/SearchPanel';
 import { RecentFilesList } from './components/RecentFilesList';
 import { FABMenu } from './components/FABMenu';
 import { useGoogleDriveSearch } from './hooks/useGoogleDriveSearch';
+import { useLocalFilePicker } from './hooks/useLocalFilePicker';
 import {
   getFileHistory,
   addFileToHistory,
@@ -71,10 +72,10 @@ function App() {
   const [fileHistory, setFileHistory] = useState<FileHistoryItem[]>([]);
 
   // Google Drive Search フック（状態を一元管理）
-  const { 
-    fetchFileContent, 
-    userInfo, 
-    isAuthenticated, 
+  const {
+    fetchFileContent,
+    userInfo,
+    isAuthenticated,
     isApiLoaded,
     authenticate,
     logout,
@@ -84,6 +85,9 @@ function App() {
     error,
     clearResults,
   } = useGoogleDriveSearch();
+
+  // ローカルファイルピッカーフック
+  const { openPicker: openLocalFilePicker } = useLocalFilePicker();
 
   // 環境変数チェック
   const hasCredentials = Boolean(
@@ -153,6 +157,16 @@ function App() {
     setFileHistory([]);
   }, []);
 
+  // ローカルファイルを選択して読み込む
+  const handleLocalFileSelect = useCallback(async () => {
+    const file = await openLocalFilePicker();
+    if (file) {
+      setMarkdownContent(file.content);
+      setFileName(file.name);
+      setShowSample(false);
+    }
+  }, [openLocalFilePicker]);
+
   // ファイルを閉じる
   const handleCloseFile = useCallback(() => {
     setMarkdownContent(null);
@@ -201,12 +215,21 @@ function App() {
               // 認証情報未設定
               <>
                 <div className="empty-icon">📂</div>
-                <h2>No file selected</h2>
-                <p>Select a Markdown file from Google Drive to preview it here.</p>
+                <h2>Markdownファイルをプレビュー</h2>
+                <p>ローカルファイルを選択してプレビューできます</p>
+                <button className="local-file-button" onClick={handleLocalFileSelect}>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" width="20" height="20">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="12" y1="18" x2="12" y2="12" />
+                    <line x1="9" y1="15" x2="15" y2="15" />
+                  </svg>
+                  ローカルファイルを開く
+                </button>
                 <div className="credentials-warning">
-                  <p>Google API credentials not configured.</p>
+                  <p>Google Drive連携を使用するには:</p>
                   <p className="hint">
-                    Set <code>VITE_GOOGLE_API_KEY</code> and <code>VITE_GOOGLE_CLIENT_ID</code> in your <code>.env</code> file.
+                    <code>VITE_GOOGLE_API_KEY</code> と <code>VITE_GOOGLE_CLIENT_ID</code> を <code>.env</code> ファイルに設定してください
                   </p>
                 </div>
                 {showSample && (
@@ -235,6 +258,18 @@ function App() {
                     <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
                   </svg>
                   Googleでログイン
+                </button>
+                <div className="login-divider">
+                  <span>または</span>
+                </div>
+                <button className="local-file-button" onClick={handleLocalFileSelect}>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" width="20" height="20">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="12" y1="18" x2="12" y2="12" />
+                    <line x1="9" y1="15" x2="15" y2="15" />
+                  </svg>
+                  ローカルファイルを開く
                 </button>
               </div>
             ) : (
@@ -273,6 +308,7 @@ function App() {
 
       <FABMenu
         onSearchClick={() => setIsSearchOpen(true)}
+        onLocalFileClick={handleLocalFileSelect}
         userInfo={userInfo}
         isAuthenticated={isAuthenticated}
         isApiLoaded={isApiLoaded}

--- a/src/components/FABMenu.tsx
+++ b/src/components/FABMenu.tsx
@@ -3,6 +3,7 @@ import type { UserInfo } from '../types/user';
 
 interface FABMenuProps {
   onSearchClick: () => void;
+  onLocalFileClick: () => void;
   userInfo: UserInfo | null;
   isAuthenticated: boolean;
   isApiLoaded: boolean;
@@ -12,6 +13,7 @@ interface FABMenuProps {
 
 export function FABMenu({
   onSearchClick,
+  onLocalFileClick,
   userInfo,
   isAuthenticated,
   isApiLoaded,
@@ -22,6 +24,11 @@ export function FABMenu({
 
   const handleSearchClick = () => {
     onSearchClick();
+    setIsOpen(false);
+  };
+
+  const handleLocalFileClick = () => {
+    onLocalFileClick();
     setIsOpen(false);
   };
 
@@ -68,6 +75,17 @@ export function FABMenu({
                 検索
               </button>
 
+              {/* ローカルファイル */}
+              <button className="fab-menu-item" onClick={handleLocalFileClick}>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="12" y1="18" x2="12" y2="12" />
+                  <line x1="9" y1="15" x2="15" y2="15" />
+                </svg>
+                ローカルファイル
+              </button>
+
               {/* ログアウト */}
               <button className="fab-menu-item logout" onClick={handleLogout}>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -79,19 +97,33 @@ export function FABMenu({
               </button>
             </>
           ) : (
-            <button
-              className="fab-menu-item login"
-              onClick={onLogin}
-              disabled={!isApiLoaded}
-            >
-              <svg viewBox="0 0 24 24" fill="currentColor">
-                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-              </svg>
-              Googleでログイン
-            </button>
+            <>
+              {/* ローカルファイル */}
+              <button className="fab-menu-item" onClick={handleLocalFileClick}>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="12" y1="18" x2="12" y2="12" />
+                  <line x1="9" y1="15" x2="15" y2="15" />
+                </svg>
+                ローカルファイル
+              </button>
+
+              {/* ログイン */}
+              <button
+                className="fab-menu-item login"
+                onClick={onLogin}
+                disabled={!isApiLoaded}
+              >
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+                </svg>
+                Googleでログイン
+              </button>
+            </>
           )}
         </div>
       )}

--- a/src/hooks/useLocalFilePicker.ts
+++ b/src/hooks/useLocalFilePicker.ts
@@ -1,0 +1,58 @@
+import { useRef, useCallback } from 'react';
+
+export interface LocalFile {
+  name: string;
+  content: string;
+}
+
+export function useLocalFilePicker() {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const openPicker = useCallback(() => {
+    // 既存の input があれば削除
+    if (inputRef.current) {
+      inputRef.current.remove();
+    }
+
+    // 新しい input を作成
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.md,.markdown,text/markdown,text/x-markdown,text/plain';
+    input.style.display = 'none';
+    inputRef.current = input;
+
+    return new Promise<LocalFile | null>((resolve) => {
+      input.onchange = async (e) => {
+        const file = (e.target as HTMLInputElement).files?.[0];
+        if (!file) {
+          resolve(null);
+          input.remove();
+          return;
+        }
+
+        try {
+          const content = await file.text();
+          resolve({
+            name: file.name,
+            content,
+          });
+        } catch (err) {
+          console.error('Failed to read file:', err);
+          resolve(null);
+        } finally {
+          input.remove();
+        }
+      };
+
+      input.oncancel = () => {
+        resolve(null);
+        input.remove();
+      };
+
+      document.body.appendChild(input);
+      input.click();
+    });
+  }, []);
+
+  return { openPicker };
+}


### PR DESCRIPTION
- Create useLocalFilePicker hook using HTML5 File API
- Add "ローカルファイル" button to FABMenu (both auth/unauth states)
- Add local file selection option to home screen
- Support .md, .markdown, and text/plain files