### PR TITLE
fix: テーブル表示とPDF出力の改善

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1220,6 +1220,12 @@ body {
     width: 24px;
     background: linear-gradient(to right, transparent, var(--color-bg-card));
     pointer-events: none;
+    transition: opacity var(--transition-fast);
+  }
+
+  /* 右端までスクロールしたときは影を非表示 */
+  .markdown-content .table-wrapper.scrolled-to-end::after {
+    opacity: 0;
   }
 }
 

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -57,6 +57,40 @@ export function MarkdownViewer({ content, fileName, onClose }: MarkdownViewerPro
   const contentRef = useRef<HTMLElement>(null);
   const { shareOrDownload, isProcessing, canShareFiles } = usePdfExport();
 
+  // テーブルのスクロール位置を監視して影を制御
+  useEffect(() => {
+    if (!contentRef.current) return;
+
+    const handleScroll = (e: Event) => {
+      const wrapper = e.target as HTMLElement;
+      if (!wrapper.classList.contains('table-wrapper')) return;
+
+      const isAtEnd = wrapper.scrollLeft + wrapper.clientWidth >= wrapper.scrollWidth - 1;
+
+      if (isAtEnd) {
+        wrapper.classList.add('scrolled-to-end');
+      } else {
+        wrapper.classList.remove('scrolled-to-end');
+      }
+    };
+
+    const tableWrappers = contentRef.current.querySelectorAll('.table-wrapper');
+    tableWrappers.forEach((wrapper) => {
+      wrapper.addEventListener('scroll', handleScroll);
+      // 初期状態をチェック
+      const isAtEnd = wrapper.scrollLeft + wrapper.clientWidth >= wrapper.scrollWidth - 1;
+      if (isAtEnd) {
+        wrapper.classList.add('scrolled-to-end');
+      }
+    });
+
+    return () => {
+      tableWrappers.forEach((wrapper) => {
+        wrapper.removeEventListener('scroll', handleScroll);
+      });
+    };
+  }, [content]);
+
   const handleShare = async () => {
     if (!contentRef.current || !fileName) return;
     await shareOrDownload(contentRef.current, fileName);

--- a/src/hooks/usePdfExport.ts
+++ b/src/hooks/usePdfExport.ts
@@ -48,6 +48,28 @@ export function usePdfExport() {
         clone.style.color = '#1a1a1a';
         clone.style.padding = '20px';
 
+        // すべてのテキスト要素に濃い色を設定
+        clone.querySelectorAll('p, td, th, li, span, div').forEach((el) => {
+          (el as HTMLElement).style.color = '#1a1a1a';
+        });
+
+        // 見出しは更に濃く
+        clone.querySelectorAll('h1, h2, h3, h4, h5, h6, strong').forEach((el) => {
+          (el as HTMLElement).style.color = '#000000';
+        });
+
+        // テーブルのヘッダーと境界線を濃く
+        clone.querySelectorAll('th').forEach((el) => {
+          (el as HTMLElement).style.backgroundColor = '#f5f5f5';
+          (el as HTMLElement).style.color = '#000000';
+          (el as HTMLElement).style.borderColor = '#cccccc';
+        });
+
+        clone.querySelectorAll('td').forEach((el) => {
+          (el as HTMLElement).style.color = '#1a1a1a';
+          (el as HTMLElement).style.borderColor = '#cccccc';
+        });
+
         // コードブロックの背景色を調整
         clone.querySelectorAll('pre, code').forEach((el) => {
           (el as HTMLElement).style.backgroundColor = '#f5f5f5';


### PR DESCRIPTION
## Summary
- テーブルの横スクロール時、右端に到達したら影を非表示にする改善
- PDF出力時のフォントカラーをより濃くして可読性を向上

## Test plan
- [ ] テーブルを含むMarkdownファイルを開き、横スクロールで右端に到達したときに影が消えることを確認
- [ ] PDF出力機能でテーブルやテキストが読みやすい色で出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)