### PR TITLE
fix: useEffect内のsetState警告を修正 & READMEを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev/)
   [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript)](https://www.typescriptlang.org/)
-  [![Vite](https://img.shields.io/badge/Vite-5.4-646CFF?logo=vite)](https://vitejs.dev/)
+  [![Vite](https://img.shields.io/badge/Vite-7-646CFF?logo=vite)](https://vitejs.dev/)
 </div>
 
 ## 機能
@@ -21,6 +21,7 @@
   - タスクリスト
   - 打ち消し線
 - 📈 Mermaid ダイアグラム対応
+- 📄 PDF 出力・共有機能（Web Share API 対応）
 - 🕐 最近使ったファイルの履歴
 - ⌨️ キーボードショートカット（`⌘K` / `Ctrl+K` で検索）
 
@@ -108,6 +109,12 @@ http://localhost:5173 でアプリにアクセスできます。
 ログイン後、ホーム画面に最近開いたファイルの履歴が表示されます。
 クリックするだけで素早くファイルを開くことができます。
 
+### PDF として出力・共有
+
+1. Markdown ファイルを開いた状態で、共有ボタンをクリック
+2. Web Share API 対応デバイス（iOS、Android など）では共有シートが表示されます
+3. 非対応デバイスでは PDF ファイルが自動ダウンロードされます
+
 ## ビルド
 
 ```bash
@@ -129,7 +136,8 @@ md-viewer/
 │   │   └── RecentFilesList.tsx  # 履歴表示
 │   ├── hooks/             # カスタムフック
 │   │   ├── useGoogleDriveSearch.ts  # Google Drive 連携
-│   │   └── useLocalFilePicker.ts    # ローカルファイル選択
+│   │   ├── useLocalFilePicker.ts    # ローカルファイル選択
+│   │   └── usePdfExport.ts          # PDF 出力・共有
 │   ├── types/             # 型定義
 │   ├── utils/             # ユーティリティ
 │   ├── App.tsx            # メインアプリケーション
@@ -141,11 +149,12 @@ md-viewer/
 ## 技術スタック
 
 - **React 19** + **TypeScript**
-- **Vite 5** - ビルドツール
+- **Vite 7** - ビルドツール
 - **react-markdown** - Markdown レンダリング
 - **remark-gfm** - GFM サポート
 - **react-syntax-highlighter** - コードハイライト
 - **Mermaid** - ダイアグラム描画
+- **html2pdf.js** - PDF 出力
 - **Google Drive API** - ファイル検索・取得
 
 ## ライセンス

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ function App() {
   const [fileName, setFileName] = useState<string | null>(null);
   const [showSample, setShowSample] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [fileHistory, setFileHistory] = useState<FileHistoryItem[]>([]);
+  const [fileHistory, setFileHistory] = useState<FileHistoryItem[]>(() => getFileHistory());
 
   // Google Drive Search フック（状態を一元管理）
   const {
@@ -103,11 +103,6 @@ function App() {
     }
   }, [hasCredentials]);
 
-  // 履歴を読み込む
-  useEffect(() => {
-    const history = getFileHistory();
-    setFileHistory(history);
-  }, []);
 
   const handleShowSample = () => {
     setMarkdownContent(SAMPLE_MARKDOWN);


### PR DESCRIPTION
## Summary
- `fileHistory` の初期化を `useState` 初期値関数に移動し、`useEffect` 内の同期的な `setState` 呼び出しを削除
- README に PDF 出力・共有機能の説明を追加
- Vite バージョン表記を 7 に更新

## Test plan
- [ ] `npm run lint` がエラーなく通ることを確認
- [ ] `npm run build` が成功することを確認
- [ ] アプリ起動時にファイル履歴が正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)