### PR TITLE
fix: モバイルでテーブルが縦長になる問題を修正

### DIFF
--- a/src/components/markdown/MarkdownRenderer.native.tsx
+++ b/src/components/markdown/MarkdownRenderer.native.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { StyleSheet, Linking } from 'react-native';
+import { StyleSheet, Linking, ScrollView, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import type { MarkdownRendererProps } from '../../types/markdown';
 import { colors, spacing, borderRadius, fontSize, fontWeight } from '../../theme';
@@ -19,12 +19,41 @@ export function MarkdownRenderer({ content, onLinkPress }: MarkdownRendererProps
     return true;
   };
 
+  // カスタムルール: テーブルを水平スクロール可能にする
+  const rules = {
+    table: (
+      node: { key: string },
+      children: React.ReactNode,
+      _parent: unknown,
+      styles: Record<string, object>
+    ) => (
+      <ScrollView
+        key={node.key}
+        horizontal
+        showsHorizontalScrollIndicator={true}
+        style={tableWrapperStyles.wrapper}
+        contentContainerStyle={tableWrapperStyles.content}
+      >
+        <View style={styles.table}>{children}</View>
+      </ScrollView>
+    ),
+  };
+
   return (
-    <Markdown style={markdownStyles} onLinkPress={handleLinkPress}>
+    <Markdown style={markdownStyles} onLinkPress={handleLinkPress} rules={rules}>
       {content}
     </Markdown>
   );
 }
+
+const tableWrapperStyles = StyleSheet.create({
+  wrapper: {
+    marginVertical: spacing.md,
+  },
+  content: {
+    flexGrow: 1,
+  },
+});
 
 const markdownStyles = StyleSheet.create({
   body: {
@@ -191,6 +220,7 @@ const markdownStyles = StyleSheet.create({
     borderRightWidth: 1,
     borderBottomWidth: 1,
     borderColor: colors.border,
+    minWidth: 80,
   },
   tr: {
     borderBottomWidth: 1,
@@ -200,6 +230,7 @@ const markdownStyles = StyleSheet.create({
     padding: spacing.sm,
     borderRightWidth: 1,
     borderColor: colors.border,
+    minWidth: 80,
   },
 
   // Image

--- a/src/components/markdown/MarkdownRenderer.web.tsx
+++ b/src/components/markdown/MarkdownRenderer.web.tsx
@@ -106,10 +106,12 @@ const webStyles = `
   .markdown-content .table-wrapper {
     overflow-x: auto;
     margin: ${spacing.md}px 0;
+    -webkit-overflow-scrolling: touch;
   }
 
   .markdown-content table {
-    width: 100%;
+    min-width: 100%;
+    width: max-content;
     border-collapse: collapse;
     font-size: 0.9rem;
   }
@@ -119,6 +121,13 @@ const webStyles = `
     padding: ${spacing.sm}px ${spacing.md}px;
     text-align: left;
     border: 1px solid ${colors.border};
+    white-space: nowrap;
+  }
+
+  .markdown-content td {
+    white-space: normal;
+    min-width: 100px;
+    max-width: 300px;
   }
 
   .markdown-content th {


### PR DESCRIPTION
## Summary
- モバイルで列数や文字数の多いテーブルが縦長に表示される問題を修正
- Web版・Native版両方で水平スクロール対応を強化
- セルの最小幅を設定して読みやすさを確保

## 変更内容

### Web版 (MarkdownRenderer.web.tsx)
- `table { width: 100% }` → `min-width: 100%; width: max-content;` に変更
- `-webkit-overflow-scrolling: touch;` でモバイルの慣性スクロール対応
- `th` に `white-space: nowrap;` 追加
- `td` に `min-width: 100px; max-width: 300px;` 追加

### Native版 (MarkdownRenderer.native.tsx)
- カスタムルールで `table` を水平 `ScrollView` でラップ
- `th`, `td` に `minWidth: 80` を追加

## Test plan
- [ ] Web版でテーブルが水平スクロールできることを確認
- [ ] iOS/Androidでテーブルが水平スクロールできることを確認
- [ ] 列数の少ないテーブルが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)