### PR TITLE
fix: モバイルでコードブロックが横にはみ出す問題を修正

### DIFF
--- a/src/components/markdown/MarkdownRenderer.web.tsx
+++ b/src/components/markdown/MarkdownRenderer.web.tsx
@@ -101,6 +101,9 @@ const webStyles = `
     margin: ${spacing.md}px 0;
     border-radius: ${borderRadius.md}px !important;
     font-size: 0.9rem !important;
+    overflow-x: auto;
+    max-width: 100%;
+    -webkit-overflow-scrolling: touch;
   }
 
   .markdown-content .table-wrapper {


### PR DESCRIPTION
## Summary
- `.code-block` クラスに `overflow-x: auto` と `max-width: 100%` を追加
- モバイルでコードブロックが親要素からはみ出さず、水平スクロールで表示されるように修正
- iOS のスムーズスクロール対応 (`-webkit-overflow-scrolling: touch`)

## Test plan
- [ ] モバイルブラウザでコードブロックを含むMarkdownを表示
- [ ] 長いコード行が横スクロールできることを確認
- [ ] コードブロックが画面外にはみ出していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)