### PR TITLE
feat: FenceとIndentedコードブロックのスタイルを分離

### DIFF
--- a/src/components/markdown/MarkdownRenderer.native.tsx
+++ b/src/components/markdown/MarkdownRenderer.native.tsx
@@ -167,7 +167,7 @@ const markdownStyles = StyleSheet.create({
     borderBottomRightRadius: borderRadius.md,
   },
 
-  // Code
+  // Code - インライン
   code_inline: {
     backgroundColor: colors.accentMuted,
     color: colors.accent,
@@ -177,23 +177,29 @@ const markdownStyles = StyleSheet.create({
     fontFamily: 'monospace',
     fontSize: fontSize.sm,
   },
+  // Indented コードブロック (4スペース) - シンプルなスタイル
   code_block: {
     backgroundColor: colors.bgTertiary,
+    borderWidth: 1,
+    borderColor: colors.border,
     padding: spacing.md,
     borderRadius: borderRadius.md,
     marginVertical: spacing.md,
     fontFamily: 'monospace',
     fontSize: fontSize.sm,
-    color: colors.textPrimary,
+    color: colors.textSecondary,
   },
+  // Fence コードブロック - 濃い背景色でハイライト風
   fence: {
-    backgroundColor: colors.bgTertiary,
+    backgroundColor: '#161b22',
+    borderWidth: 1,
+    borderColor: '#30363d',
     padding: spacing.md,
     borderRadius: borderRadius.md,
     marginVertical: spacing.md,
     fontFamily: 'monospace',
     fontSize: fontSize.sm,
-    color: colors.textPrimary,
+    color: '#e6edf3',
   },
 
   // Horizontal Rule


### PR DESCRIPTION
## Summary

- GitHub風にFenceとIndentedコードブロックのスタイルを区別
- Web版・Native版両方でスタイルを分離

## Changes

### Web版
| 種類 | スタイル |
|------|----------|
| Fence (言語指定あり) | シンタックスハイライト + 言語ヘッダー + 濃い背景 |
| Indented/言語なし | プレーンテキスト + 薄い背景 + ボーダー |

### Native版
| 種類 | 背景色 |
|------|--------|
| Fence | `#161b22` (GitHub Dark) |
| Code Block | `bgTertiary` |

## Test plan

- [ ] Fenceコードブロック（言語指定あり）がシンタックスハイライトで表示される
- [ ] Indentedコードブロックがシンプルなスタイルで表示される
- [ ] Mermaidダイアグラムが正しく表示される
- [ ] インラインコードが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)