### PR TITLE
fix: トークン復元待機とデバッグログを追加

### DIFF
--- a/app/search.tsx
+++ b/app/search.tsx
@@ -36,9 +36,12 @@ export default function SearchScreen() {
 
   // 画面表示時に入力欄にフォーカス
   useEffect(() => {
+    console.log('[SearchScreen] フォーカス useEffect - isAuthenticated:', isAuthenticated);
+    console.log('[SearchScreen] inputRef.current:', inputRef.current);
     if (isAuthenticated) {
       // 少し遅延させてフォーカス（モーダルアニメーション後）
       const timer = setTimeout(() => {
+        console.log('[SearchScreen] フォーカス実行, inputRef:', inputRef.current);
         inputRef.current?.focus();
       }, 100);
       return () => clearTimeout(timer);

--- a/src/hooks/useGoogleAuth.web.ts
+++ b/src/hooks/useGoogleAuth.web.ts
@@ -148,15 +148,20 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
 
   // 初期化時にトークンを復元
   useEffect(() => {
+    console.log('[useGoogleAuth] トークン復元開始');
     restoreToken().then((stored) => {
+      console.log('[useGoogleAuth] restoreToken結果:', stored ? 'トークンあり' : 'トークンなし');
       if (stored) {
+        console.log('[useGoogleAuth] トークン設定:', stored.token.substring(0, 20) + '...');
         setAccessToken(stored.token);
         setIsAuthenticated(true);
         fetchUserInfo(stored.token).then((info) => {
+          console.log('[useGoogleAuth] ユーザー情報:', info);
           if (info) setUserInfo(info);
         });
       }
       setIsTokenRestored(true);
+      console.log('[useGoogleAuth] トークン復元完了');
     });
   }, []);
 
@@ -273,29 +278,38 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
   // ファイル内容を取得
   const fetchFileContent = useCallback(
     async (fileId: string, signal?: AbortSignal): Promise<string | null> => {
+      console.log('[fetchFileContent] 開始 fileId:', fileId);
+      console.log('[fetchFileContent] accessToken:', accessToken ? accessToken.substring(0, 20) + '...' : 'null');
+      console.log('[fetchFileContent] isTokenRestored:', isTokenRestored);
+      console.log('[fetchFileContent] isAuthenticated:', isAuthenticated);
+
       if (!accessToken) {
+        console.error('[fetchFileContent] トークンなし!');
         setError('認証が必要です。再度ログインしてください。');
         return null;
       }
 
       try {
-        return await fetchDriveFileContent(
+        console.log('[fetchFileContent] API呼び出し開始');
+        const result = await fetchDriveFileContent(
           accessToken,
           fileId,
           signal
         );
+        console.log('[fetchFileContent] API呼び出し成功, 長さ:', result?.length);
+        return result;
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') {
           throw err;
         }
+        console.error('[fetchFileContent] エラー:', err);
         setError(
           err instanceof Error ? err.message : 'Failed to fetch file content'
         );
-        console.error('Error fetching file content:', err);
         return null;
       }
     },
-    [accessToken]
+    [accessToken, isTokenRestored, isAuthenticated]
   );
 
   // 検索結果をクリア


### PR DESCRIPTION
## Summary
- 履歴からファイル読み込み時にトークン復元を待機するよう修正
- 問題調査用のデバッグログを追加

## 変更詳細

### viewer.tsx
- `isAuthLoading` と `accessToken` を useEffect の依存配列に追加
- トークン復元が完了するまでファイル読み込みを待機
- トークンがない場合は適切なエラーメッセージを表示

### useGoogleAuth.web.ts
- トークン復元プロセスのログ出力
- `fetchFileContent` のログ出力

### search.tsx
- フォーカス処理のログ出力

## Test plan
- [ ] ブラウザコンソールでログが出力される
- [ ] 履歴からファイルを開く際、トークン復元を待機する
- [ ] 型エラーなし (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)