### PR TITLE
feat: Localize UI to English and add About page

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -5,11 +5,11 @@ import { colors, spacing, fontSize } from '../src/theme';
 export default function NotFoundScreen() {
   return (
     <>
-      <Stack.Screen options={{ title: 'ページが見つかりません' }} />
+      <Stack.Screen options={{ title: 'Page Not Found' }} />
       <View style={styles.container}>
-        <Text style={styles.title}>ページが見つかりません</Text>
+        <Text style={styles.title}>Page Not Found</Text>
         <Link href="/" style={styles.link}>
-          <Text style={styles.linkText}>ホームに戻る</Text>
+          <Text style={styles.linkText}>Go to Home</Text>
         </Link>
       </View>
     </>

--- a/app/about.tsx
+++ b/app/about.tsx
@@ -1,0 +1,332 @@
+/**
+ * MD Viewer - About Screen
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { colors, spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
+
+export default function AboutScreen() {
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>About MD Viewer</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView
+        style={styles.content}
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Hero */}
+        <View style={styles.hero}>
+          <Image
+            source={require('../assets/images/icon.png')}
+            style={styles.heroIcon}
+            resizeMode="contain"
+          />
+          <Text style={styles.heroTitle}>MD Viewer</Text>
+          <Text style={styles.heroVersion}>Version 1.0.0</Text>
+        </View>
+
+        {/* Description */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>What is MD Viewer?</Text>
+          <Text style={styles.sectionText}>
+            MD Viewer is a web application that beautifully renders Markdown files
+            stored in your Google Drive. It provides a seamless reading experience
+            with syntax highlighting, diagram support, and PDF export capabilities.
+          </Text>
+        </View>
+
+        {/* Features */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Features</Text>
+
+          <View style={styles.featureList}>
+            <View style={styles.featureItem}>
+              <View style={styles.featureIcon}>
+                <Ionicons name="logo-google" size={20} color={colors.accent} />
+              </View>
+              <View style={styles.featureContent}>
+                <Text style={styles.featureTitle}>Google Drive Integration</Text>
+                <Text style={styles.featureDescription}>
+                  Connect your Google account and search for Markdown files
+                  directly from your Drive. Quick access to your documents
+                  without downloading.
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.featureItem}>
+              <View style={styles.featureIcon}>
+                <Ionicons name="code-slash-outline" size={20} color={colors.accent} />
+              </View>
+              <View style={styles.featureContent}>
+                <Text style={styles.featureTitle}>Syntax Highlighting</Text>
+                <Text style={styles.featureDescription}>
+                  Code blocks are rendered with syntax highlighting for
+                  various programming languages including JavaScript, Python,
+                  TypeScript, and more.
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.featureItem}>
+              <View style={styles.featureIcon}>
+                <Ionicons name="git-network-outline" size={20} color={colors.accent} />
+              </View>
+              <View style={styles.featureContent}>
+                <Text style={styles.featureTitle}>Mermaid Diagrams</Text>
+                <Text style={styles.featureDescription}>
+                  Create flowcharts, sequence diagrams, and other visualizations
+                  using Mermaid syntax. Diagrams are rendered automatically
+                  within your documents.
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.featureItem}>
+              <View style={styles.featureIcon}>
+                <Ionicons name="document-outline" size={20} color={colors.accent} />
+              </View>
+              <View style={styles.featureContent}>
+                <Text style={styles.featureTitle}>PDF Export</Text>
+                <Text style={styles.featureDescription}>
+                  Export your rendered Markdown documents as PDF files.
+                  Perfect for sharing documentation or creating printable
+                  versions of your notes.
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.featureItem}>
+              <View style={styles.featureIcon}>
+                <Ionicons name="folder-outline" size={20} color={colors.accent} />
+              </View>
+              <View style={styles.featureContent}>
+                <Text style={styles.featureTitle}>Local File Support</Text>
+                <Text style={styles.featureDescription}>
+                  Open Markdown files from your local device without signing in.
+                  Great for quick previews or when working offline.
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.featureItem}>
+              <View style={styles.featureIcon}>
+                <Ionicons name="time-outline" size={20} color={colors.accent} />
+              </View>
+              <View style={styles.featureContent}>
+                <Text style={styles.featureTitle}>Recent Files</Text>
+                <Text style={styles.featureDescription}>
+                  Quick access to recently viewed files. Your reading history
+                  is stored locally for convenience.
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        {/* Supported Formats */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Supported Markdown Features</Text>
+          <View style={styles.chipContainer}>
+            <View style={styles.chip}><Text style={styles.chipText}>Headers</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Bold / Italic</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Lists</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Tables</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Code Blocks</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Links</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Images</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Blockquotes</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Task Lists</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Strikethrough</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>Mermaid</Text></View>
+            <View style={styles.chip}><Text style={styles.chipText}>GFM</Text></View>
+          </View>
+        </View>
+
+        {/* Privacy */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Privacy & Security</Text>
+          <Text style={styles.sectionText}>
+            MD Viewer only requests read-only access to your Google Drive files.
+            Your documents are never stored on our servers - they are fetched
+            directly from Google Drive and rendered in your browser.
+            Your authentication tokens are stored securely in your browser's
+            local storage.
+          </Text>
+        </View>
+
+        {/* Footer */}
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            Built with Expo and React Native Web
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgPrimary,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.bgSecondary,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    color: colors.textPrimary,
+    textAlign: 'center',
+  },
+  headerSpacer: {
+    width: 40,
+  },
+  content: {
+    flex: 1,
+  },
+  contentContainer: {
+    padding: spacing.xl,
+    maxWidth: 700,
+    alignSelf: 'center',
+    width: '100%',
+  },
+
+  // Hero
+  hero: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+  },
+  heroIcon: {
+    width: 80,
+    height: 80,
+    borderRadius: borderRadius.lg,
+  },
+  heroTitle: {
+    fontSize: fontSize['2xl'],
+    fontWeight: fontWeight.bold,
+    color: colors.textPrimary,
+    marginTop: spacing.md,
+  },
+  heroVersion: {
+    fontSize: fontSize.sm,
+    color: colors.textMuted,
+    marginTop: spacing.xs,
+  },
+
+  // Sections
+  section: {
+    marginTop: spacing.xl,
+  },
+  sectionTitle: {
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    color: colors.textPrimary,
+    marginBottom: spacing.md,
+  },
+  sectionText: {
+    fontSize: fontSize.base,
+    color: colors.textSecondary,
+    lineHeight: fontSize.base * 1.6,
+  },
+
+  // Feature List
+  featureList: {
+    gap: spacing.lg,
+  },
+  featureItem: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  featureIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.accentMuted,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  featureContent: {
+    flex: 1,
+  },
+  featureTitle: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.semibold,
+    color: colors.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  featureDescription: {
+    fontSize: fontSize.sm,
+    color: colors.textSecondary,
+    lineHeight: fontSize.sm * 1.5,
+  },
+
+  // Chips
+  chipContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  chip: {
+    backgroundColor: colors.bgTertiary,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.full,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+  },
+  chipText: {
+    fontSize: fontSize.sm,
+    color: colors.textSecondary,
+  },
+
+  // Footer
+  footer: {
+    marginTop: spacing['2xl'],
+    paddingTop: spacing.xl,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    alignItems: 'center',
+  },
+  footerText: {
+    fontSize: fontSize.sm,
+    color: colors.textMuted,
+  },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -37,7 +37,6 @@ export default function HomeScreen() {
   const [recentFiles, setRecentFiles] = useState<FileHistoryItem[]>([]);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
 
-  // 履歴を読み込む
   useEffect(() => {
     loadHistory();
   }, []);
@@ -47,7 +46,6 @@ export default function HomeScreen() {
     setRecentFiles(history);
   };
 
-  // ローカルファイルを選択
   const handleLocalFile = useCallback(async () => {
     setIsUserMenuOpen(false);
     const file = await openPicker();
@@ -57,7 +55,6 @@ export default function HomeScreen() {
         name: file.name,
         source: 'local',
       });
-      // ビューアーに遷移（内容をパラメータで渡す）
       router.push({
         pathname: '/viewer',
         params: {
@@ -70,12 +67,10 @@ export default function HomeScreen() {
     }
   }, [openPicker]);
 
-  // Google Drive 検索を開く
   const handleOpenSearch = useCallback(() => {
     router.push('/search');
   }, []);
 
-  // 履歴からファイルを開く
   const handleOpenHistoryFile = useCallback((item: FileHistoryItem) => {
     router.push({
       pathname: '/viewer',
@@ -87,13 +82,15 @@ export default function HomeScreen() {
     });
   }, []);
 
-  // 履歴をクリア
   const handleClearHistory = useCallback(async () => {
     await clearFileHistory();
     setRecentFiles([]);
   }, []);
 
-  // 相対時間を計算
+  const handleOpenAbout = useCallback(() => {
+    router.push('/about');
+  }, []);
+
   const formatRelativeTime = (dateString: string): string => {
     const date = new Date(dateString);
     const now = new Date();
@@ -102,11 +99,11 @@ export default function HomeScreen() {
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
 
-    if (minutes < 1) return 'たった今';
-    if (minutes < 60) return `${minutes}分前`;
-    if (hours < 24) return `${hours}時間前`;
-    if (days < 7) return `${days}日前`;
-    return date.toLocaleDateString('ja-JP');
+    if (minutes < 1) return 'Just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    if (days < 7) return `${days}d ago`;
+    return date.toLocaleDateString('en-US');
   };
 
   return (
@@ -135,42 +132,93 @@ export default function HomeScreen() {
         style={styles.content}
         contentContainerStyle={styles.contentContainer}
       >
-        {/* Empty State / Login Prompt */}
+        {/* Landing Page for Non-authenticated Users */}
         {!isAuthenticated ? (
-          <View style={styles.emptyState}>
-            <Image
-              source={require('../assets/images/icon.png')}
-              style={styles.welcomeIcon}
-              resizeMode="contain"
-            />
-            <Text style={styles.emptyTitle}>MD Viewer へようこそ</Text>
-            <Text style={styles.emptyDescription}>
-              Google Drive の Markdown ファイルを{'\n'}美しく表示します
-            </Text>
-
-            <Button
-              onPress={authenticate}
-              disabled={!isApiLoaded}
-              loading={isLoading}
-              style={styles.loginButton}
-              icon={<Ionicons name="logo-google" size={20} color={colors.bgPrimary} />}
-            >
-              Google でログイン
-            </Button>
-
-            <View style={styles.divider}>
-              <View style={styles.dividerLine} />
-              <Text style={styles.dividerText}>または</Text>
-              <View style={styles.dividerLine} />
+          <View style={styles.landingContainer}>
+            {/* Hero Section */}
+            <View style={styles.heroSection}>
+              <Image
+                source={require('../assets/images/icon.png')}
+                style={styles.heroIcon}
+                resizeMode="contain"
+              />
+              <Text style={styles.heroTitle}>Welcome to MD Viewer</Text>
+              <Text style={styles.heroSubtitle}>
+                A beautiful Markdown viewer for{'\n'}Google Drive
+              </Text>
             </View>
 
-            <Button
-              variant="outline"
-              onPress={handleLocalFile}
-              icon={<Ionicons name="folder-outline" size={20} color={colors.accent} />}
-            >
-              ローカルファイルを開く
-            </Button>
+            {/* Features Section */}
+            <View style={styles.featuresSection}>
+              <View style={styles.featureCard}>
+                <View style={styles.featureIconContainer}>
+                  <Ionicons name="logo-google" size={24} color={colors.accent} />
+                </View>
+                <View style={styles.featureContent}>
+                  <Text style={styles.featureTitle}>Google Drive Integration</Text>
+                  <Text style={styles.featureDescription}>
+                    Search and open Markdown files directly from your Google Drive
+                  </Text>
+                </View>
+              </View>
+
+              <View style={styles.featureCard}>
+                <View style={styles.featureIconContainer}>
+                  <Ionicons name="color-palette-outline" size={24} color={colors.accent} />
+                </View>
+                <View style={styles.featureContent}>
+                  <Text style={styles.featureTitle}>Beautiful Rendering</Text>
+                  <Text style={styles.featureDescription}>
+                    Syntax highlighting, Mermaid diagrams, and clean typography
+                  </Text>
+                </View>
+              </View>
+
+              <View style={styles.featureCard}>
+                <View style={styles.featureIconContainer}>
+                  <Ionicons name="share-outline" size={24} color={colors.accent} />
+                </View>
+                <View style={styles.featureContent}>
+                  <Text style={styles.featureTitle}>Export to PDF</Text>
+                  <Text style={styles.featureDescription}>
+                    Share your documents as beautifully formatted PDFs
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            {/* CTA Section */}
+            <View style={styles.ctaSection}>
+              <Button
+                onPress={authenticate}
+                disabled={!isApiLoaded}
+                loading={isLoading}
+                style={styles.ctaButton}
+                icon={<Ionicons name="logo-google" size={20} color={colors.bgPrimary} />}
+              >
+                Sign in with Google
+              </Button>
+
+              <View style={styles.divider}>
+                <View style={styles.dividerLine} />
+                <Text style={styles.dividerText}>or</Text>
+                <View style={styles.dividerLine} />
+              </View>
+
+              <Button
+                variant="outline"
+                onPress={handleLocalFile}
+                icon={<Ionicons name="folder-outline" size={20} color={colors.accent} />}
+              >
+                Open Local File
+              </Button>
+            </View>
+
+            {/* Learn More Link */}
+            <TouchableOpacity style={styles.learnMoreLink} onPress={handleOpenAbout}>
+              <Text style={styles.learnMoreText}>Learn more about MD Viewer</Text>
+              <Ionicons name="arrow-forward" size={16} color={colors.accent} />
+            </TouchableOpacity>
           </View>
         ) : (
           <View style={styles.authenticatedContent}>
@@ -178,7 +226,7 @@ export default function HomeScreen() {
             <Pressable style={styles.searchBox} onPress={handleOpenSearch}>
               <Ionicons name="search" size={20} color={colors.textMuted} />
               <Text style={styles.searchPlaceholder}>
-                Google Drive を検索...
+                Search Google Drive...
               </Text>
               {Platform.OS === 'web' && (
                 <View style={styles.kbd}>
@@ -191,9 +239,9 @@ export default function HomeScreen() {
             {recentFiles.length > 0 && (
               <View style={styles.recentSection}>
                 <View style={styles.recentHeader}>
-                  <Text style={styles.recentTitle}>最近のファイル</Text>
+                  <Text style={styles.recentTitle}>Recent Files</Text>
                   <TouchableOpacity onPress={handleClearHistory}>
-                    <Text style={styles.clearButton}>クリア</Text>
+                    <Text style={styles.clearButton}>Clear</Text>
                   </TouchableOpacity>
                 </View>
 
@@ -249,14 +297,18 @@ export default function HomeScreen() {
             )}
             <TouchableOpacity style={styles.userMenuItem} onPress={handleLocalFile}>
               <Ionicons name="folder-outline" size={20} color={colors.textSecondary} />
-              <Text style={styles.userMenuText}>ローカルファイルを開く</Text>
+              <Text style={styles.userMenuText}>Open Local File</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.userMenuItem} onPress={handleOpenAbout}>
+              <Ionicons name="information-circle-outline" size={20} color={colors.textSecondary} />
+              <Text style={styles.userMenuText}>About MD Viewer</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.userMenuItem, styles.userMenuLogout]}
               onPress={logout}
             >
               <Ionicons name="log-out-outline" size={20} color={colors.error} />
-              <Text style={[styles.userMenuText, { color: colors.error }]}>ログアウト</Text>
+              <Text style={[styles.userMenuText, { color: colors.error }]}>Sign Out</Text>
             </TouchableOpacity>
           </View>
         </>
@@ -312,41 +364,88 @@ const styles = StyleSheet.create({
     padding: spacing.xl,
   },
 
-  // Empty State
-  emptyState: {
+  // Landing Page
+  landingContainer: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: spacing['2xl'],
+    maxWidth: 600,
+    alignSelf: 'center',
+    width: '100%',
   },
-  welcomeIcon: {
-    width: 120,
-    height: 120,
+  heroSection: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+  },
+  heroIcon: {
+    width: 100,
+    height: 100,
     borderRadius: borderRadius.xl,
   },
-  emptyTitle: {
+  heroTitle: {
     fontSize: fontSize['2xl'],
-    fontWeight: fontWeight.semibold,
+    fontWeight: fontWeight.bold,
     color: colors.textPrimary,
     marginTop: spacing.lg,
     marginBottom: spacing.sm,
+    textAlign: 'center',
   },
-  emptyDescription: {
-    fontSize: fontSize.base,
+  heroSubtitle: {
+    fontSize: fontSize.lg,
     color: colors.textSecondary,
     textAlign: 'center',
-    marginBottom: spacing.xl,
-    lineHeight: fontSize.base * 1.5,
+    lineHeight: fontSize.lg * 1.5,
   },
-  loginButton: {
-    marginBottom: spacing.lg,
+
+  // Features
+  featuresSection: {
+    marginTop: spacing.xl,
+    gap: spacing.md,
+  },
+  featureCard: {
+    flexDirection: 'row',
+    backgroundColor: colors.bgCard,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  featureIconContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.accentMuted,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  featureContent: {
+    flex: 1,
+  },
+  featureTitle: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.semibold,
+    color: colors.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  featureDescription: {
+    fontSize: fontSize.sm,
+    color: colors.textSecondary,
+    lineHeight: fontSize.sm * 1.5,
+  },
+
+  // CTA
+  ctaSection: {
+    marginTop: spacing['2xl'],
+    alignItems: 'center',
+  },
+  ctaButton: {
+    marginBottom: spacing.md,
   },
   divider: {
     flexDirection: 'row',
     alignItems: 'center',
     width: '100%',
     maxWidth: 280,
-    marginVertical: spacing.lg,
+    marginVertical: spacing.md,
   },
   dividerLine: {
     flex: 1,
@@ -357,6 +456,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     color: colors.textMuted,
     fontSize: fontSize.sm,
+  },
+
+  // Learn More
+  learnMoreLink: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: spacing.xl,
+    gap: spacing.xs,
+  },
+  learnMoreText: {
+    fontSize: fontSize.sm,
+    color: colors.accent,
   },
 
   // Authenticated Content

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -34,21 +34,15 @@ export default function SearchScreen() {
   const [query, setQuery] = useState('');
   const inputRef = useRef<TextInput>(null);
 
-  // 画面表示時に入力欄にフォーカス
   useEffect(() => {
-    console.log('[SearchScreen] フォーカス useEffect - isAuthenticated:', isAuthenticated);
-    console.log('[SearchScreen] inputRef.current:', inputRef.current);
     if (isAuthenticated) {
-      // 少し遅延させてフォーカス（モーダルアニメーション後）
       const timer = setTimeout(() => {
-        console.log('[SearchScreen] フォーカス実行, inputRef:', inputRef.current);
         inputRef.current?.focus();
       }, 100);
       return () => clearTimeout(timer);
     }
   }, [isAuthenticated]);
 
-  // 検索を実行
   const handleSearch = useCallback(
     (text: string) => {
       setQuery(text);
@@ -61,7 +55,6 @@ export default function SearchScreen() {
     [search, clearResults]
   );
 
-  // ファイルを選択
   const handleSelectFile = useCallback((file: DriveFile) => {
     router.replace({
       pathname: '/viewer',
@@ -73,12 +66,10 @@ export default function SearchScreen() {
     });
   }, []);
 
-  // 閉じる
   const handleClose = useCallback(() => {
     router.back();
   }, []);
 
-  // 相対時間を計算
   const formatRelativeTime = (dateString?: string): string => {
     if (!dateString) return '';
     const date = new Date(dateString);
@@ -88,14 +79,13 @@ export default function SearchScreen() {
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
 
-    if (days > 30) return date.toLocaleDateString('ja-JP');
-    if (days > 0) return `${days}日前`;
-    if (hours > 0) return `${hours}時間前`;
-    if (minutes > 0) return `${minutes}分前`;
-    return 'たった今';
+    if (days > 30) return date.toLocaleDateString('en-US');
+    if (days > 0) return `${days}d ago`;
+    if (hours > 0) return `${hours}h ago`;
+    if (minutes > 0) return `${minutes}m ago`;
+    return 'Just now';
   };
 
-  // ファイルサイズをフォーマット
   const formatFileSize = (sizeString?: string): string => {
     if (!sizeString) return '';
     const bytes = parseInt(sizeString, 10);
@@ -104,7 +94,6 @@ export default function SearchScreen() {
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
-  // 検索結果のアイテムをレンダリング
   const renderResultItem = useCallback(
     ({ item }: { item: DriveFile }) => (
       <TouchableOpacity
@@ -151,7 +140,7 @@ export default function SearchScreen() {
             <TextInput
               ref={inputRef}
               style={styles.searchInput}
-              placeholder="Google Drive を検索..."
+              placeholder="Search Google Drive..."
               placeholderTextColor={colors.textMuted}
               value={query}
               onChangeText={handleSearch}
@@ -172,11 +161,11 @@ export default function SearchScreen() {
           {!isAuthenticated ? (
             <View style={styles.authPrompt}>
               <Text style={styles.authText}>
-                Google Drive を検索するには{'\n'}ログインしてください
+                Please sign in to search{'\n'}Google Drive
               </Text>
               <TouchableOpacity style={styles.authButton} onPress={authenticate}>
                 <Ionicons name="logo-google" size={20} color={colors.bgPrimary} />
-                <Text style={styles.authButtonText}>Google でログイン</Text>
+                <Text style={styles.authButtonText}>Sign in with Google</Text>
               </TouchableOpacity>
             </View>
           ) : query.length === 0 ? (
@@ -184,23 +173,23 @@ export default function SearchScreen() {
               <View style={styles.emptyIcon}>
                 <Ionicons name="search-outline" size={48} color={colors.textMuted} />
               </View>
-              <Text style={styles.emptyTitle}>Markdown ファイルを検索</Text>
+              <Text style={styles.emptyTitle}>Search Markdown Files</Text>
               <Text style={styles.emptyHint}>
-                2文字以上入力すると検索が開始されます
+                Type at least 2 characters to start searching
               </Text>
             </View>
           ) : query.length < 2 ? (
             <View style={styles.messageContainer}>
-              <Text style={styles.messageText}>2文字以上入力してください</Text>
+              <Text style={styles.messageText}>Type at least 2 characters</Text>
             </View>
           ) : results.length === 0 && !isLoading ? (
             <View style={styles.emptyState}>
               <View style={styles.emptyIcon}>
                 <Ionicons name="document-outline" size={48} color={colors.textMuted} />
               </View>
-              <Text style={styles.emptyTitle}>結果が見つかりません</Text>
+              <Text style={styles.emptyTitle}>No Results Found</Text>
               <Text style={styles.emptyHint}>
-                別のキーワードで検索してみてください
+                Try searching with different keywords
               </Text>
             </View>
           ) : (
@@ -213,7 +202,7 @@ export default function SearchScreen() {
               ListHeaderComponent={
                 results.length > 0 ? (
                   <Text style={styles.resultsHeader}>
-                    {results.length} 件の結果
+                    {results.length} {results.length === 1 ? 'result' : 'results'}
                   </Text>
                 ) : null
               }

--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -36,73 +36,53 @@ export default function ViewerScreen() {
   const [isLoading, setIsLoading] = useState(!params.content);
   const [error, setError] = useState<string | null>(null);
 
-  console.log('[ViewerScreen] render - params:', params);
-  console.log('[ViewerScreen] isAuthLoading:', isAuthLoading, 'isAuthenticated:', isAuthenticated);
-  console.log('[ViewerScreen] accessToken:', accessToken ? 'あり' : 'なし');
-
-  // Google Drive からファイル内容を取得
   useEffect(() => {
-    console.log('[ViewerScreen] useEffect triggered');
-    console.log('[ViewerScreen] source:', params.source, 'content:', params.content ? 'あり' : 'なし');
-    console.log('[ViewerScreen] isAuthLoading:', isAuthLoading, 'accessToken:', accessToken ? 'あり' : 'なし');
-
     if (params.source === 'google-drive' && !params.content) {
-      // トークン復元が完了するまで待つ
       if (isAuthLoading) {
-        console.log('[ViewerScreen] 認証ローディング中、待機...');
         return;
       }
       if (!accessToken) {
-        console.log('[ViewerScreen] トークンなし、エラー設定');
-        setError('認証が必要です。ホームに戻ってログインしてください。');
+        setError('Authentication required. Please go back to home and sign in.');
         setIsLoading(false);
         return;
       }
-      console.log('[ViewerScreen] loadFileContent呼び出し');
       loadFileContent();
     }
   }, [params.id, params.source, params.content, isAuthLoading, accessToken]);
 
   const loadFileContent = async () => {
-    console.log('[loadFileContent] 開始');
     setIsLoading(true);
     setError(null);
 
     try {
       const fileContent = await fetchFileContent(params.id);
-      console.log('[loadFileContent] 結果:', fileContent ? `${fileContent.length}文字` : 'null');
       if (fileContent) {
         setContent(fileContent);
-        // 履歴に追加
         await addFileToHistory({
           id: params.id,
           name: params.name,
           source: 'google-drive',
         });
       } else {
-        setError('ファイルの読み込みに失敗しました');
+        setError('Failed to load file');
       }
     } catch (err) {
-      console.error('[loadFileContent] エラー:', err);
-      setError(err instanceof Error ? err.message : 'エラーが発生しました');
+      setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
       setIsLoading(false);
     }
   };
 
-  // 共有
   const handleShare = async () => {
     if (content && params.name) {
       await shareContent(content, params.name);
     }
   };
 
-  // 戻る
   const handleBack = () => {
     router.back();
   };
 
-  // リンクを開く
   const handleLinkPress = (url: string) => {
     window.open(url, '_blank');
   };
@@ -143,14 +123,14 @@ export default function ViewerScreen() {
       {isLoading ? (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.accent} />
-          <Text style={styles.loadingText}>読み込み中...</Text>
+          <Text style={styles.loadingText}>Loading...</Text>
         </View>
       ) : error ? (
         <View style={styles.errorContainer}>
           <Ionicons name="alert-circle-outline" size={48} color={colors.error} />
           <Text style={styles.errorText}>{error}</Text>
           <TouchableOpacity style={styles.retryButton} onPress={loadFileContent}>
-            <Text style={styles.retryText}>再試行</Text>
+            <Text style={styles.retryText}>Retry</Text>
           </TouchableOpacity>
         </View>
       ) : content ? (
@@ -166,7 +146,7 @@ export default function ViewerScreen() {
       ) : (
         <View style={styles.emptyContainer}>
           <Ionicons name="document-outline" size={48} color={colors.textMuted} />
-          <Text style={styles.emptyText}>コンテンツがありません</Text>
+          <Text style={styles.emptyText}>No content</Text>
         </View>
       )}
     </SafeAreaView>


### PR DESCRIPTION
## Summary

- Convert all UI text from Japanese to English across all screens
- Add rich landing page for non-authenticated users with feature highlights
- Add new About page (`/about`) with comprehensive service documentation

## Changes

### UI Localization (Japanese → English)
- `app/index.tsx` - Home screen
- `app/search.tsx` - Search screen
- `app/viewer.tsx` - Viewer screen
- `app/+not-found.tsx` - 404 page

### New Landing Page (Non-authenticated)
- Hero section with app icon and tagline
- Feature cards highlighting:
  - Google Drive Integration
  - Beautiful Rendering (syntax highlighting, Mermaid)
  - Export to PDF
- "Learn more" link to About page

### New About Page (`app/about.tsx`)
- Service overview
- Detailed feature explanations (6 items)
- Supported Markdown features (chips display)
- Privacy & Security information

## Test plan

- [ ] Non-authenticated: Landing page displays feature cards
- [ ] Non-authenticated: "Learn more" link navigates to About page
- [ ] Authenticated: User menu includes "About MD Viewer" option
- [ ] About page displays all sections correctly
- [ ] All UI text is in English
- [ ] Type check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)