### PR TITLE
feat: Improve PDF export with better rendering and Mermaid support

### DIFF
--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -15,7 +15,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { colors, spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
-import { Card, IconButton } from '../src/components/ui';
+import { Card } from '../src/components/ui';
 import { MarkdownRenderer } from '../src/components/markdown';
 import { useGoogleAuth, useShare } from '../src/hooks';
 import { addFileToHistory } from '../src/services';
@@ -73,7 +73,7 @@ export default function ViewerScreen() {
     }
   };
 
-  const handleShare = async () => {
+  const handleDownloadPdf = async () => {
     if (content && params.name) {
       await shareContent(content, params.name);
     }
@@ -105,17 +105,24 @@ export default function ViewerScreen() {
           </Text>
         </View>
         <View style={styles.headerActions}>
-          <IconButton
-            icon={
-              isProcessing ? (
-                <ActivityIndicator size="small" color={colors.accent} />
-              ) : (
-                <Ionicons name="share-outline" size={20} color={colors.textMuted} />
-              )
-            }
-            onPress={handleShare}
+          <TouchableOpacity
+            style={[
+              styles.pdfButton,
+              (isProcessing || !content) && styles.pdfButtonDisabled,
+            ]}
+            onPress={handleDownloadPdf}
             disabled={isProcessing || !content}
-          />
+            activeOpacity={0.7}
+          >
+            {isProcessing ? (
+              <ActivityIndicator size="small" color={colors.bgPrimary} />
+            ) : (
+              <>
+                <Ionicons name="download-outline" size={16} color={colors.bgPrimary} />
+                <Text style={styles.pdfButtonText}>PDF</Text>
+              </>
+            )}
+          </TouchableOpacity>
         </View>
       </View>
 
@@ -190,6 +197,23 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
+  },
+  pdfButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    backgroundColor: colors.accent,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+  },
+  pdfButtonDisabled: {
+    opacity: 0.5,
+  },
+  pdfButtonText: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.semibold,
+    color: colors.bgPrimary,
   },
 
   // Loading

--- a/src/hooks/useShare.web.ts
+++ b/src/hooks/useShare.web.ts
@@ -1,98 +1,59 @@
 /**
- * 共有 hook - Web 版
- * Web Share API と html2pdf.js を使用（必要に応じてダウンロード）
+ * PDF Download hook - Web version
+ * Uses html2pdf.js for PDF generation and download
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
+import { markdownToHtml } from '../utils/markdownToHtml';
 
 export interface UseShareReturn {
   shareContent: (content: string, fileName: string) => Promise<void>;
   exportToPdf: (content: string, fileName: string) => Promise<string | null>;
   isProcessing: boolean;
   error: string | null;
-  canShare: boolean;
-}
-
-// シンプルな Markdown → HTML 変換
-function markdownToHtml(content: string): string {
-  let html = content
-    // コードブロック
-    .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre style="background:#f5f5f5;padding:12px;border-radius:4px;overflow-x:auto;"><code>$2</code></pre>')
-    // インラインコード
-    .replace(/`([^`]+)`/g, '<code style="background:#f0f0f0;padding:2px 4px;border-radius:2px;">$1</code>')
-    // 見出し
-    .replace(/^### (.+)$/gm, '<h3 style="color:#000;margin:16px 0 8px;">$1</h3>')
-    .replace(/^## (.+)$/gm, '<h2 style="color:#000;margin:20px 0 10px;border-bottom:1px solid #ddd;padding-bottom:4px;">$1</h2>')
-    .replace(/^# (.+)$/gm, '<h1 style="color:#000;margin:24px 0 12px;border-bottom:2px solid #ddd;padding-bottom:6px;">$1</h1>')
-    // 太字
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    // 斜体
-    .replace(/\*(.+?)\*/g, '<em>$1</em>')
-    // リンク
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:#0066cc;">$1</a>')
-    // リスト
-    .replace(/^- (.+)$/gm, '<li>$1</li>')
-    // 水平線
-    .replace(/^---$/gm, '<hr style="border:none;border-top:1px solid #ddd;margin:16px 0;">')
-    // 段落
-    .replace(/\n\n/g, '</p><p style="margin:0 0 12px;line-height:1.6;">');
-
-  html = html.replace(/(<li>.*?<\/li>)+/gs, '<ul style="margin:12px 0;padding-left:24px;">$&</ul>');
-
-  return `<p style="margin:0 0 12px;line-height:1.6;">${html}</p>`;
 }
 
 export function useShare(): UseShareReturn {
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Web Share API がファイル共有をサポートしているかチェック
-  const canShare = useMemo(() => {
-    if (typeof navigator === 'undefined') return false;
-    if (!navigator.share || !navigator.canShare) return false;
-    try {
-      const testFile = new File(['test'], 'test.pdf', { type: 'application/pdf' });
-      return navigator.canShare({ files: [testFile] });
-    } catch {
-      return false;
-    }
-  }, []);
-
-  // PDF を生成（html2pdf.js を動的にロード）
+  // Generate PDF and return Blob URL
   const exportToPdf = useCallback(
     async (content: string, fileName: string): Promise<string | null> => {
       setIsProcessing(true);
       setError(null);
 
       try {
-        // html2pdf.js を動的にインポート
         const html2pdf = (await import('html2pdf.js')).default;
 
-        const htmlContent = markdownToHtml(content);
+        const htmlContent = await markdownToHtml(content);
         const container = document.createElement('div');
         container.innerHTML = `
-          <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:14px;color:#1a1a1a;line-height:1.6;padding:20px;">
+          <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:11px;color:#1a1a1a;line-height:1.6;padding:16px;">
             ${htmlContent}
           </div>
         `;
 
         const pdfFileName = fileName.replace(/\.(md|markdown)$/i, '') + '.pdf';
 
+        const pdfOptions = {
+          margin: [10, 10, 10, 10],
+          filename: pdfFileName,
+          image: { type: 'jpeg', quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true, logging: false, backgroundColor: '#ffffff' },
+          jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+          pagebreak: { mode: ['avoid-all', 'css', 'legacy'] },
+        };
+
         const blob = await html2pdf()
-          .set({
-            margin: 10,
-            filename: pdfFileName,
-            image: { type: 'jpeg', quality: 0.98 },
-            html2canvas: { scale: 2, useCORS: true, logging: false, backgroundColor: '#ffffff' },
-            jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
-          })
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .set(pdfOptions as any)
           .from(container)
           .outputPdf('blob');
 
-        // Blob URL を返す
         return URL.createObjectURL(blob);
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'PDF生成に失敗しました';
+        const message = err instanceof Error ? err.message : 'PDF generation failed';
         setError(message);
         console.error('PDF export failed:', err);
         return null;
@@ -103,68 +64,58 @@ export function useShare(): UseShareReturn {
     []
   );
 
-  // コンテンツを共有
+  // Generate and download PDF
   const shareContent = useCallback(
     async (content: string, fileName: string): Promise<void> => {
       setIsProcessing(true);
       setError(null);
 
       try {
-        // html2pdf.js を動的にインポート
         const html2pdf = (await import('html2pdf.js')).default;
 
-        const htmlContent = markdownToHtml(content);
+        const htmlContent = await markdownToHtml(content);
         const container = document.createElement('div');
         container.innerHTML = `
-          <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:14px;color:#1a1a1a;line-height:1.6;padding:20px;">
+          <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:11px;color:#1a1a1a;line-height:1.6;padding:16px;">
             ${htmlContent}
           </div>
         `;
 
         const pdfFileName = fileName.replace(/\.(md|markdown)$/i, '') + '.pdf';
 
+        const pdfOptions = {
+          margin: [10, 10, 10, 10],
+          filename: pdfFileName,
+          image: { type: 'jpeg', quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true, logging: false, backgroundColor: '#ffffff' },
+          jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+          pagebreak: { mode: ['avoid-all', 'css', 'legacy'] },
+        };
+
         const blob = await html2pdf()
-          .set({
-            margin: 10,
-            filename: pdfFileName,
-            image: { type: 'jpeg', quality: 0.98 },
-            html2canvas: { scale: 2, useCORS: true, logging: false, backgroundColor: '#ffffff' },
-            jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
-          })
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .set(pdfOptions as any)
           .from(container)
           .outputPdf('blob');
 
-        if (canShare) {
-          // Web Share API で共有
-          const file = new File([blob], pdfFileName, { type: 'application/pdf' });
-          await navigator.share({
-            files: [file],
-            title: pdfFileName.replace('.pdf', ''),
-          });
-        } else {
-          // ダウンロード
-          const url = URL.createObjectURL(blob);
-          const link = document.createElement('a');
-          link.href = url;
-          link.download = pdfFileName;
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
-        }
+        // Always download
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = pdfFileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
       } catch (err) {
-        // ユーザーがキャンセルした場合はエラーとしない
-        if (err instanceof Error && err.name === 'AbortError') {
-          return;
-        }
-        const message = err instanceof Error ? err.message : '共有に失敗しました';
+        const message = err instanceof Error ? err.message : 'PDF download failed';
         setError(message);
-        console.error('Share failed:', err);
+        console.error('PDF download failed:', err);
       } finally {
         setIsProcessing(false);
       }
     },
-    [canShare]
+    []
   );
 
   return {
@@ -172,6 +123,5 @@ export function useShare(): UseShareReturn {
     exportToPdf,
     isProcessing,
     error,
-    canShare,
   };
 }

--- a/src/utils/markdownToHtml.test.ts
+++ b/src/utils/markdownToHtml.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for markdownToHtml function
+ * Run with: npx tsx src/utils/markdownToHtml.test.ts
+ */
+
+import { markdownToHtml } from './markdownToHtml';
+
+interface TestCase {
+  name: string;
+  input: string;
+  expectedContains: string[];
+  expectedNotContains?: string[];
+}
+
+const testCases: TestCase[] = [
+  // Headings
+  {
+    name: 'H1 heading',
+    input: '# Hello World',
+    expectedContains: ['<h1', '>Hello World</h1>'],
+  },
+  {
+    name: 'H2 heading',
+    input: '## Section Title',
+    expectedContains: ['<h2', '>Section Title</h2>'],
+  },
+  {
+    name: 'H3 heading',
+    input: '### Subsection',
+    expectedContains: ['<h3', '>Subsection</h3>'],
+  },
+  {
+    name: 'H4 heading',
+    input: '#### Level 4',
+    expectedContains: ['<h4', '>Level 4</h4>'],
+    expectedNotContains: ['####'],
+  },
+  {
+    name: 'H5 heading',
+    input: '##### Level 5',
+    expectedContains: ['<h5', '>Level 5</h5>'],
+    expectedNotContains: ['#####'],
+  },
+  {
+    name: 'H6 heading',
+    input: '###### Level 6',
+    expectedContains: ['<h6', '>Level 6</h6>'],
+    expectedNotContains: ['######'],
+  },
+
+  // Text formatting
+  {
+    name: 'Bold text with **',
+    input: 'This is **bold** text',
+    expectedContains: ['<strong>bold</strong>'],
+    expectedNotContains: ['**'],
+  },
+  {
+    name: 'Italic text with *',
+    input: 'This is *italic* text',
+    expectedContains: ['<em>italic</em>'],
+  },
+  {
+    name: 'Strikethrough',
+    input: 'This is ~~deleted~~ text',
+    expectedContains: ['<del>deleted</del>'],
+    expectedNotContains: ['~~'],
+  },
+
+  // Lists - Unordered
+  {
+    name: 'Unordered list with -',
+    input: '- Item 1\n- Item 2\n- Item 3',
+    expectedContains: ['<ul', '<li>Item 1</li>', '<li>Item 2</li>', '<li>Item 3</li>', '</ul>'],
+    expectedNotContains: ['- Item'],
+  },
+  {
+    name: 'Unordered list with *',
+    input: '* Apple\n* Banana\n* Cherry',
+    expectedContains: ['<ul', '<li>Apple</li>', '<li>Banana</li>', '</ul>'],
+    expectedNotContains: ['* Apple'],
+  },
+  {
+    name: 'Unordered list with +',
+    input: '+ One\n+ Two',
+    expectedContains: ['<ul', '<li>One</li>', '<li>Two</li>', '</ul>'],
+  },
+
+  // Lists - Ordered
+  {
+    name: 'Ordered list',
+    input: '1. First\n2. Second\n3. Third',
+    expectedContains: ['<ol', '<li>First</li>', '<li>Second</li>', '<li>Third</li>', '</ol>'],
+    expectedNotContains: ['1. First', '2. Second'],
+  },
+
+  // Task lists
+  {
+    name: 'Task list unchecked',
+    input: '- [ ] Todo item',
+    expectedContains: ['<input type="checkbox" disabled', 'Todo item'],
+    expectedNotContains: ['[ ]'],
+  },
+  {
+    name: 'Task list checked',
+    input: '- [x] Done item',
+    expectedContains: ['<input type="checkbox" checked disabled', 'Done item'],
+    expectedNotContains: ['[x]'],
+  },
+
+  // Tables
+  {
+    name: 'Simple table',
+    input: '| Name | Age |\n|------|-----|\n| John | 30 |\n| Jane | 25 |',
+    expectedContains: [
+      '<table',
+      '<thead>',
+      '<th',
+      '>Name</th>',
+      '>Age</th>',
+      '</thead>',
+      '<tbody>',
+      '<td',
+      '>John</td>',
+      '>30</td>',
+      '>Jane</td>',
+      '>25</td>',
+      '</tbody>',
+      '</table>',
+    ],
+    expectedNotContains: ['|---'],
+  },
+
+  // Code
+  {
+    name: 'Inline code',
+    input: 'Use `console.log()` for debugging',
+    expectedContains: ['<code', '>console.log()</code>'],
+    expectedNotContains: ['`console'],
+  },
+  {
+    name: 'Code block',
+    input: '```js\nconst x = 1;\n```',
+    expectedContains: ['<pre', '<code>', 'const x = 1;', '</code>', '</pre>'],
+    expectedNotContains: ['```'],
+  },
+  {
+    name: 'Code block escapes HTML',
+    input: '```html\n<div>test</div>\n```',
+    expectedContains: ['&lt;div&gt;', '&lt;/div&gt;'],
+    expectedNotContains: ['<div>test</div>'],
+  },
+
+  // Links and Images
+  {
+    name: 'Link',
+    input: 'Visit [Google](https://google.com)',
+    expectedContains: ['<a href="https://google.com"', '>Google</a>'],
+    expectedNotContains: ['[Google]'],
+  },
+  {
+    name: 'Image',
+    input: '![Alt text](https://example.com/image.png)',
+    expectedContains: ['<img src="https://example.com/image.png"', 'alt="Alt text"'],
+  },
+
+  // Blockquote
+  {
+    name: 'Blockquote',
+    input: '> This is a quote',
+    expectedContains: ['<blockquote', '>This is a quote</blockquote>'],
+    expectedNotContains: ['> This'],
+  },
+
+  // Horizontal rule
+  {
+    name: 'Horizontal rule ---',
+    input: '---',
+    expectedContains: ['<hr'],
+    expectedNotContains: ['---'],
+  },
+
+  // Complex document
+  {
+    name: 'Complex document',
+    input: `# Title
+
+This is a paragraph with **bold** and *italic* text.
+
+## Features
+
+- Feature 1
+- Feature 2
+- Feature 3
+
+### Code Example
+
+\`\`\`javascript
+function hello() {
+  console.log("Hello");
+}
+\`\`\`
+
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+`,
+    expectedContains: [
+      '<h1',
+      '>Title</h1>',
+      '<strong>bold</strong>',
+      '<em>italic</em>',
+      '<h2',
+      '>Features</h2>',
+      '<ul',
+      '<li>Feature 1</li>',
+      '</ul>',
+      '<h3',
+      '>Code Example</h3>',
+      '<pre',
+      '<code>',
+      'function hello()',
+      '</code>',
+      '</pre>',
+      '<table',
+      '<th',
+      '>Header 1</th>',
+      '<td',
+      '>Cell 1</td>',
+    ],
+  },
+
+  // Mermaid (basic test - just check it's processed)
+  // Note: In Node.js environment without DOM, Mermaid falls back to code display
+  {
+    name: 'Mermaid block placeholder',
+    input: '```mermaid\ngraph TD\n    A-->B\n```',
+    expectedContains: ['<pre', '<code>', 'graph TD'], // Fallback in Node.js environment
+    expectedNotContains: ['```mermaid'],
+  },
+];
+
+async function runTests(): Promise<void> {
+  let passed = 0;
+  let failed = 0;
+  const failures: { name: string; error: string; html: string }[] = [];
+
+  console.log('Running markdownToHtml tests...\n');
+
+  for (const testCase of testCases) {
+    const html = await markdownToHtml(testCase.input);
+    let testPassed = true;
+    let errorMessages: string[] = [];
+
+    // Check expected contains
+    for (const expected of testCase.expectedContains) {
+      if (!html.includes(expected)) {
+        testPassed = false;
+        errorMessages.push(`Missing: "${expected}"`);
+      }
+    }
+
+    // Check expected not contains
+    if (testCase.expectedNotContains) {
+      for (const notExpected of testCase.expectedNotContains) {
+        if (html.includes(notExpected)) {
+          testPassed = false;
+          errorMessages.push(`Should not contain: "${notExpected}"`);
+        }
+      }
+    }
+
+    if (testPassed) {
+      console.log(`✓ ${testCase.name}`);
+      passed++;
+    } else {
+      console.log(`✗ ${testCase.name}`);
+      errorMessages.forEach((msg) => console.log(`  ${msg}`));
+      failures.push({ name: testCase.name, error: errorMessages.join('; '), html });
+      failed++;
+    }
+  }
+
+  console.log(`\n${'='.repeat(50)}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+
+  if (failures.length > 0) {
+    console.log(`\n${'='.repeat(50)}`);
+    console.log('Failed test outputs:\n');
+    for (const failure of failures) {
+      console.log(`--- ${failure.name} ---`);
+      console.log('Input HTML:');
+      console.log(failure.html);
+      console.log('');
+    }
+    process.exit(1);
+  }
+}
+
+runTests();

--- a/src/utils/markdownToHtml.ts
+++ b/src/utils/markdownToHtml.ts
@@ -1,0 +1,256 @@
+/**
+ * Markdown to HTML converter for PDF export
+ */
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+interface MermaidBlock {
+  index: number;
+  code: string;
+}
+
+export async function markdownToHtml(content: string): Promise<string> {
+  let html = content;
+
+  // Store code blocks and mermaid blocks separately
+  const codeBlocks: string[] = [];
+  const mermaidBlocks: MermaidBlock[] = [];
+
+  // Extract mermaid blocks first
+  html = html.replace(/```mermaid\n([\s\S]*?)```/g, (_, code) => {
+    const index = mermaidBlocks.length;
+    mermaidBlocks.push({ index, code: code.trim() });
+    return `\n<<<MERMAID${index}>>>\n`;
+  });
+
+  // Extract other code blocks
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
+    const index = codeBlocks.length;
+    const langLabel = lang ? `<div style="font-size:9px;color:#666;margin-bottom:4px;">${lang}</div>` : '';
+    codeBlocks.push(
+      `<pre style="background:#f5f5f5;padding:10px;border-radius:4px;overflow-x:auto;font-size:10px;page-break-inside:avoid;">${langLabel}<code>${escapeHtml(code.trimEnd())}</code></pre>`
+    );
+    return `\n<<<CODEBLOCK${index}>>>\n`;
+  });
+
+  // Tables
+  html = html.replace(
+    /^\|(.+)\|\s*\n\|[-:\s|]+\|\s*\n((?:\|.+\|\s*\n?)+)/gm,
+    (_, header, body) => {
+      const headerCells = header
+        .split('|')
+        .map((c: string) => c.trim())
+        .filter(Boolean);
+      const headerRow = headerCells
+        .map(
+          (c: string) =>
+            `<th style="border:1px solid #ddd;padding:6px;background:#f5f5f5;text-align:left;font-size:10px;">${c}</th>`
+        )
+        .join('');
+
+      const bodyRows = body
+        .trim()
+        .split('\n')
+        .map((row: string) => {
+          const cells = row
+            .split('|')
+            .map((c: string) => c.trim())
+            .filter(Boolean);
+          return `<tr>${cells.map((c: string) => `<td style="border:1px solid #ddd;padding:6px;font-size:10px;">${c}</td>`).join('')}</tr>`;
+        })
+        .join('');
+
+      return `\n<table style="border-collapse:collapse;margin:12px 0;width:100%;page-break-inside:avoid;"><thead><tr>${headerRow}</tr></thead><tbody>${bodyRows}</tbody></table>\n`;
+    }
+  );
+
+  // Inline code (before other inline formatting)
+  html = html.replace(
+    /`([^`]+)`/g,
+    '<code style="background:#f0f0f0;padding:1px 4px;border-radius:3px;font-size:10px;">$1</code>'
+  );
+
+  // Headings (order matters: h6 to h1)
+  // page-break-after: avoid prevents heading from being at bottom of page without content
+  html = html.replace(/^###### (.+)$/gm, '<h6 style="color:#000;margin:8px 0 4px;font-size:11px;page-break-after:avoid;">$1</h6>');
+  html = html.replace(/^##### (.+)$/gm, '<h5 style="color:#000;margin:8px 0 4px;font-size:12px;page-break-after:avoid;">$1</h5>');
+  html = html.replace(/^#### (.+)$/gm, '<h4 style="color:#000;margin:10px 0 5px;font-size:13px;page-break-after:avoid;">$1</h4>');
+  html = html.replace(/^### (.+)$/gm, '<h3 style="color:#000;margin:12px 0 6px;font-size:14px;page-break-after:avoid;">$1</h3>');
+  html = html.replace(
+    /^## (.+)$/gm,
+    '<h2 style="color:#000;margin:14px 0 7px;font-size:16px;border-bottom:1px solid #ddd;padding-bottom:3px;page-break-after:avoid;">$1</h2>'
+  );
+  html = html.replace(
+    /^# (.+)$/gm,
+    '<h1 style="color:#000;margin:16px 0 8px;font-size:20px;border-bottom:2px solid #ddd;padding-bottom:4px;page-break-after:avoid;">$1</h1>'
+  );
+
+  // Blockquotes (before list processing)
+  html = html.replace(
+    /^> (.+)$/gm,
+    '<blockquote style="border-left:3px solid #ddd;margin:8px 0;padding:6px 12px;color:#666;page-break-inside:avoid;">$1</blockquote>'
+  );
+
+  // Horizontal rule (before list processing to avoid * conflicts)
+  html = html.replace(/^---$/gm, '<hr style="border:none;border-top:1px solid #ddd;margin:12px 0;">');
+  html = html.replace(/^\*\*\*$/gm, '<hr style="border:none;border-top:1px solid #ddd;margin:12px 0;">');
+  html = html.replace(/^___$/gm, '<hr style="border:none;border-top:1px solid #ddd;margin:12px 0;">');
+
+  // Process lists BEFORE bold/italic (to avoid * conflicts)
+  const lines = html.split('\n');
+  const processedLines: string[] = [];
+  let inOrderedList = false;
+  let inUnorderedList = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const taskMatch = line.match(/^[-*+] \[([ xX])\] (.+)$/);
+    const orderedMatch = line.match(/^(\d+)\. (.+)$/);
+    const unorderedMatch = line.match(/^[-*+] (.+)$/);
+
+    if (taskMatch) {
+      // Task list item
+      if (inOrderedList) {
+        processedLines.push('</ol>');
+        inOrderedList = false;
+      }
+      if (!inUnorderedList) {
+        processedLines.push('<ul style="margin:8px 0;padding-left:20px;list-style:none;">');
+        inUnorderedList = true;
+      }
+      const checked = taskMatch[1].toLowerCase() === 'x';
+      const checkbox = checked
+        ? '<input type="checkbox" checked disabled style="margin-right:6px;">'
+        : '<input type="checkbox" disabled style="margin-right:6px;">';
+      processedLines.push(`<li style="list-style:none;">${checkbox}${taskMatch[2]}</li>`);
+    } else if (orderedMatch) {
+      // Ordered list item
+      if (inUnorderedList) {
+        processedLines.push('</ul>');
+        inUnorderedList = false;
+      }
+      if (!inOrderedList) {
+        processedLines.push('<ol style="margin:8px 0;padding-left:20px;">');
+        inOrderedList = true;
+      }
+      processedLines.push(`<li>${orderedMatch[2]}</li>`);
+    } else if (unorderedMatch) {
+      // Unordered list item
+      if (inOrderedList) {
+        processedLines.push('</ol>');
+        inOrderedList = false;
+      }
+      if (!inUnorderedList) {
+        processedLines.push('<ul style="margin:8px 0;padding-left:20px;">');
+        inUnorderedList = true;
+      }
+      processedLines.push(`<li>${unorderedMatch[1]}</li>`);
+    } else {
+      // Close any open lists
+      if (inOrderedList) {
+        processedLines.push('</ol>');
+        inOrderedList = false;
+      }
+      if (inUnorderedList) {
+        processedLines.push('</ul>');
+        inUnorderedList = false;
+      }
+      processedLines.push(line);
+    }
+  }
+
+  // Close any remaining open lists
+  if (inOrderedList) {
+    processedLines.push('</ol>');
+  }
+  if (inUnorderedList) {
+    processedLines.push('</ul>');
+  }
+
+  html = processedLines.join('\n');
+
+  // Bold and Italic (AFTER list processing)
+  html = html.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/(?<!\*)\*([^*\n]+)\*(?!\*)/g, '<em>$1</em>');
+  html = html.replace(/___(.+?)___/g, '<strong><em>$1</em></strong>');
+  html = html.replace(/__(.+?)__/g, '<strong>$1</strong>');
+  html = html.replace(/(?<!_)_([^_\n]+)_(?!_)/g, '<em>$1</em>');
+
+  // Strikethrough
+  html = html.replace(/~~(.+?)~~/g, '<del>$1</del>');
+
+  // Images (before links)
+  html = html.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    '<img src="$2" alt="$1" style="max-width:100%;height:auto;margin:8px 0;">'
+  );
+
+  // Links
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:#0066cc;">$1</a>');
+
+  // Restore code blocks
+  codeBlocks.forEach((block, index) => {
+    html = html.replace(`<<<CODEBLOCK${index}>>>`, block);
+  });
+
+  // Render mermaid blocks
+  if (mermaidBlocks.length > 0) {
+    try {
+      const mermaid = (await import('mermaid')).default;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'default',
+        securityLevel: 'loose',
+      });
+
+      for (const block of mermaidBlocks) {
+        try {
+          const { svg } = await mermaid.render(`mermaid-${block.index}`, block.code);
+          // Wrap SVG in a container with proper styling
+          const wrappedSvg = `<div style="margin:12px 0;text-align:center;overflow-x:auto;page-break-inside:avoid;">${svg}</div>`;
+          html = html.replace(`<<<MERMAID${block.index}>>>`, wrappedSvg);
+        } catch (err) {
+          console.error(`Mermaid render error for block ${block.index}:`, err);
+          // Fallback to showing the code
+          const fallback = `<pre style="background:#fff3cd;padding:10px;border-radius:4px;border:1px solid #ffc107;font-size:10px;page-break-inside:avoid;"><code>${escapeHtml(block.code)}</code></pre>`;
+          html = html.replace(`<<<MERMAID${block.index}>>>`, fallback);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to load mermaid:', err);
+      // Fallback all mermaid blocks to code
+      for (const block of mermaidBlocks) {
+        const fallback = `<pre style="background:#f5f5f5;padding:10px;border-radius:4px;font-size:10px;page-break-inside:avoid;"><code>${escapeHtml(block.code)}</code></pre>`;
+        html = html.replace(`<<<MERMAID${block.index}>>>`, fallback);
+      }
+    }
+  }
+
+  // Convert double newlines to paragraph breaks
+  html = html.split('\n\n').map(para => {
+    const trimmed = para.trim();
+    if (!trimmed) return '';
+    // Don't wrap block elements in paragraphs
+    if (trimmed.startsWith('<h') ||
+        trimmed.startsWith('<ul') ||
+        trimmed.startsWith('<ol') ||
+        trimmed.startsWith('<table') ||
+        trimmed.startsWith('<blockquote') ||
+        trimmed.startsWith('<pre') ||
+        trimmed.startsWith('<hr') ||
+        trimmed.startsWith('<div')) {
+      return trimmed;
+    }
+    return `<p style="margin:0 0 8px;line-height:1.5;">${trimmed.replace(/\n/g, '<br>')}</p>`;
+  }).filter(Boolean).join('\n');
+
+  return html;
+}


### PR DESCRIPTION
## Summary
- Add dedicated `markdownToHtml` converter with comprehensive Markdown support including Mermaid diagrams
- Improve page break handling to prevent content from being split across pages
- Reduce font sizes for better PDF density
- Change PDF button to explicit download button with icon + "PDF" label

## Changes

### New markdownToHtml converter (`src/utils/markdownToHtml.ts`)
- Headings (h1-h6) with proper sizing
- Bold, italic, strikethrough
- Ordered/unordered/task lists
- Tables with styling
- Code blocks with syntax highlighting label
- Inline code
- Links, images, blockquotes, horizontal rules
- **Mermaid diagram support** (renders to SVG in browser, falls back to code display)

### PDF improvements
- `page-break-inside: avoid` for code blocks, tables, blockquotes, Mermaid diagrams
- `page-break-after: avoid` for headings (prevents orphaned headers)
- html2pdf `pagebreak` option with `avoid-all`, `css`, `legacy` modes
- Reduced font sizes: base 14px → 11px, proportionally smaller for other elements

### UI changes
- PDF button now shows download icon + "PDF" text
- Always downloads PDF (removed Web Share API logic for consistency)

## Test plan
- [x] All 25 markdownToHtml tests pass
- [x] TypeScript type check passes
- [ ] Manual test: Export a Markdown file with tables to PDF, verify no content splitting
- [ ] Manual test: Export a Markdown file with code blocks to PDF
- [ ] Manual test: Export a Markdown file with Mermaid diagrams to PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)