### PR TITLE
feat: Add English/Japanese language toggle

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@
 import { Stack } from 'expo-router';
 import { View, StyleSheet } from 'react-native';
 import { ThemeProvider } from '../src/contexts/ThemeContext';
+import { LanguageProvider } from '../src/contexts/LanguageContext';
 import { useTheme } from '../src/hooks';
 
 export { ErrorBoundary } from 'expo-router';
@@ -47,7 +48,9 @@ function RootLayoutContent() {
 export default function RootLayout() {
   return (
     <ThemeProvider>
-      <RootLayoutContent />
+      <LanguageProvider>
+        <RootLayoutContent />
+      </LanguageProvider>
     </ThemeProvider>
   );
 }

--- a/app/about.tsx
+++ b/app/about.tsx
@@ -15,11 +15,12 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
-import { useTheme } from '../src/hooks';
-import { ThemeToggle } from '../src/components/ui';
+import { useTheme, useLanguage } from '../src/hooks';
+import { ThemeToggle, LanguageToggle } from '../src/components/ui';
 
 export default function AboutScreen() {
   const { colors } = useTheme();
+  const { t } = useLanguage();
 
   const handleBack = () => {
     router.back();
@@ -32,8 +33,11 @@ export default function AboutScreen() {
         <TouchableOpacity style={styles.backButton} onPress={handleBack}>
           <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </TouchableOpacity>
-        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>About MD Viewer</Text>
-        <ThemeToggle />
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t.about.title}</Text>
+        <View style={styles.headerActions}>
+          <LanguageToggle />
+          <ThemeToggle />
+        </View>
       </View>
 
       <ScrollView
@@ -48,23 +52,21 @@ export default function AboutScreen() {
             style={styles.heroIcon}
             resizeMode="contain"
           />
-          <Text style={[styles.heroTitle, { color: colors.textPrimary }]}>MD Viewer</Text>
-          <Text style={[styles.heroVersion, { color: colors.textMuted }]}>Version 1.0.0</Text>
+          <Text style={[styles.heroTitle, { color: colors.textPrimary }]}>{t.about.appName}</Text>
+          <Text style={[styles.heroVersion, { color: colors.textMuted }]}>{t.about.version.replace('{version}', '1.0.0')}</Text>
         </View>
 
         {/* Description */}
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>What is MD Viewer?</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>{t.about.whatIs}</Text>
           <Text style={[styles.sectionText, { color: colors.textSecondary }]}>
-            MD Viewer is a web application that beautifully renders Markdown files
-            stored in your Google Drive. It provides a seamless reading experience
-            with syntax highlighting, diagram support, and PDF export capabilities.
+            {t.about.description}
           </Text>
         </View>
 
         {/* Features */}
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>Features</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>{t.about.features}</Text>
 
           <View style={styles.featureList}>
             <View style={styles.featureItem}>
@@ -72,11 +74,9 @@ export default function AboutScreen() {
                 <Ionicons name="logo-google" size={20} color={colors.accent} />
               </View>
               <View style={styles.featureContent}>
-                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Google Drive Integration</Text>
+                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.about.feature.drive.title}</Text>
                 <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                  Connect your Google account and search for Markdown files
-                  directly from your Drive. Quick access to your documents
-                  without downloading.
+                  {t.about.feature.drive.desc}
                 </Text>
               </View>
             </View>
@@ -86,11 +86,9 @@ export default function AboutScreen() {
                 <Ionicons name="code-slash-outline" size={20} color={colors.accent} />
               </View>
               <View style={styles.featureContent}>
-                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Syntax Highlighting</Text>
+                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.about.feature.syntax.title}</Text>
                 <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                  Code blocks are rendered with syntax highlighting for
-                  various programming languages including JavaScript, Python,
-                  TypeScript, and more.
+                  {t.about.feature.syntax.desc}
                 </Text>
               </View>
             </View>
@@ -100,11 +98,9 @@ export default function AboutScreen() {
                 <Ionicons name="git-network-outline" size={20} color={colors.accent} />
               </View>
               <View style={styles.featureContent}>
-                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Mermaid Diagrams</Text>
+                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.about.feature.mermaid.title}</Text>
                 <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                  Create flowcharts, sequence diagrams, and other visualizations
-                  using Mermaid syntax. Diagrams are rendered automatically
-                  within your documents.
+                  {t.about.feature.mermaid.desc}
                 </Text>
               </View>
             </View>
@@ -114,11 +110,9 @@ export default function AboutScreen() {
                 <Ionicons name="document-outline" size={20} color={colors.accent} />
               </View>
               <View style={styles.featureContent}>
-                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>PDF Export</Text>
+                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.about.feature.pdf.title}</Text>
                 <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                  Export your rendered Markdown documents as PDF files.
-                  Perfect for sharing documentation or creating printable
-                  versions of your notes.
+                  {t.about.feature.pdf.desc}
                 </Text>
               </View>
             </View>
@@ -128,10 +122,9 @@ export default function AboutScreen() {
                 <Ionicons name="folder-outline" size={20} color={colors.accent} />
               </View>
               <View style={styles.featureContent}>
-                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Local File Support</Text>
+                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.about.feature.local.title}</Text>
                 <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                  Open Markdown files from your local device without signing in.
-                  Great for quick previews or when working offline.
+                  {t.about.feature.local.desc}
                 </Text>
               </View>
             </View>
@@ -141,10 +134,9 @@ export default function AboutScreen() {
                 <Ionicons name="time-outline" size={20} color={colors.accent} />
               </View>
               <View style={styles.featureContent}>
-                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Recent Files</Text>
+                <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.about.feature.recent.title}</Text>
                 <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                  Quick access to recently viewed files. Your reading history
-                  is stored locally for convenience.
+                  {t.about.feature.recent.desc}
                 </Text>
               </View>
             </View>
@@ -153,9 +145,22 @@ export default function AboutScreen() {
 
         {/* Supported Formats */}
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>Supported Markdown Features</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>{t.about.supported}</Text>
           <View style={styles.chipContainer}>
-            {['Headers', 'Bold / Italic', 'Lists', 'Tables', 'Code Blocks', 'Links', 'Images', 'Blockquotes', 'Task Lists', 'Strikethrough', 'Mermaid', 'GFM'].map((label) => (
+            {[
+              t.about.chips.headers,
+              t.about.chips.boldItalic,
+              t.about.chips.lists,
+              t.about.chips.tables,
+              t.about.chips.codeBlocks,
+              t.about.chips.links,
+              t.about.chips.images,
+              t.about.chips.blockquotes,
+              t.about.chips.taskLists,
+              t.about.chips.strikethrough,
+              t.about.chips.mermaid,
+              t.about.chips.gfm,
+            ].map((label) => (
               <View key={label} style={[styles.chip, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}>
                 <Text style={[styles.chipText, { color: colors.textSecondary }]}>{label}</Text>
               </View>
@@ -165,20 +170,16 @@ export default function AboutScreen() {
 
         {/* Privacy */}
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>Privacy & Security</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>{t.about.privacy}</Text>
           <Text style={[styles.sectionText, { color: colors.textSecondary }]}>
-            MD Viewer only requests read-only access to your Google Drive files.
-            Your documents are never stored on our servers - they are fetched
-            directly from Google Drive and rendered in your browser.
-            Your authentication tokens are stored securely in your browser's
-            local storage.
+            {t.about.privacyDesc}
           </Text>
         </View>
 
         {/* Footer */}
         <View style={[styles.footer, { borderTopColor: colors.border }]}>
           <Text style={[styles.footerText, { color: colors.textMuted }]}>
-            Built with Expo and React Native Web
+            {t.about.footer}
           </Text>
         </View>
       </ScrollView>
@@ -208,6 +209,11 @@ const styles = StyleSheet.create({
     fontSize: fontSize.lg,
     fontWeight: fontWeight.semibold,
     textAlign: 'center',
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
   },
   content: {
     flex: 1,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -17,14 +17,15 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { spacing, borderRadius, fontSize, fontWeight, shadows } from '../src/theme';
-import { Button, LoadingSpinner, FAB, ThemeToggle } from '../src/components/ui';
-import { useGoogleAuth, useTheme } from '../src/hooks';
+import { Button, LoadingSpinner, FAB, ThemeToggle, LanguageToggle } from '../src/components/ui';
+import { useGoogleAuth, useTheme, useLanguage } from '../src/hooks';
 import { useFilePicker } from '../src/hooks';
 import { getFileHistory, clearFileHistory, addFileToHistory } from '../src/services';
 import type { FileHistoryItem } from '../src/types';
 
 export default function HomeScreen() {
   const { colors } = useTheme();
+  const { t, language } = useLanguage();
   const {
     isLoading,
     isApiLoaded,
@@ -100,11 +101,11 @@ export default function HomeScreen() {
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
 
-    if (minutes < 1) return 'Just now';
-    if (minutes < 60) return `${minutes}m ago`;
-    if (hours < 24) return `${hours}h ago`;
-    if (days < 7) return `${days}d ago`;
-    return date.toLocaleDateString('en-US');
+    if (minutes < 1) return t.common.justNow;
+    if (minutes < 60) return t.common.minutesAgo.replace('{min}', String(minutes));
+    if (hours < 24) return t.common.hoursAgo.replace('{hours}', String(hours));
+    if (days < 7) return t.common.daysAgo.replace('{days}', String(days));
+    return date.toLocaleDateString(language === 'ja' ? 'ja-JP' : 'en-US');
   };
 
   return (
@@ -118,6 +119,7 @@ export default function HomeScreen() {
             resizeMode="contain"
           />
           <View style={styles.headerActions}>
+            <LanguageToggle />
             <ThemeToggle />
             {isAuthenticated && userInfo && (
               <TouchableOpacity
@@ -146,9 +148,9 @@ export default function HomeScreen() {
                 style={styles.heroIcon}
                 resizeMode="contain"
               />
-              <Text style={[styles.heroTitle, { color: colors.textPrimary }]}>Welcome to MD Viewer</Text>
+              <Text style={[styles.heroTitle, { color: colors.textPrimary }]}>{t.home.welcome}</Text>
               <Text style={[styles.heroSubtitle, { color: colors.textSecondary }]}>
-                A beautiful Markdown viewer for{'\n'}Google Drive
+                {t.home.subtitle}
               </Text>
             </View>
 
@@ -159,9 +161,9 @@ export default function HomeScreen() {
                   <Ionicons name="logo-google" size={24} color={colors.accent} />
                 </View>
                 <View style={styles.featureContent}>
-                  <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Google Drive Integration</Text>
+                  <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.home.feature.drive.title}</Text>
                   <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                    Search and open Markdown files directly from your Google Drive
+                    {t.home.feature.drive.desc}
                   </Text>
                 </View>
               </View>
@@ -171,9 +173,9 @@ export default function HomeScreen() {
                   <Ionicons name="color-palette-outline" size={24} color={colors.accent} />
                 </View>
                 <View style={styles.featureContent}>
-                  <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Beautiful Rendering</Text>
+                  <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.home.feature.rendering.title}</Text>
                   <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                    Syntax highlighting, Mermaid diagrams, and clean typography
+                    {t.home.feature.rendering.desc}
                   </Text>
                 </View>
               </View>
@@ -183,9 +185,9 @@ export default function HomeScreen() {
                   <Ionicons name="share-outline" size={24} color={colors.accent} />
                 </View>
                 <View style={styles.featureContent}>
-                  <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>Export to PDF</Text>
+                  <Text style={[styles.featureTitle, { color: colors.textPrimary }]}>{t.home.feature.pdf.title}</Text>
                   <Text style={[styles.featureDescription, { color: colors.textSecondary }]}>
-                    Share your documents as beautifully formatted PDFs
+                    {t.home.feature.pdf.desc}
                   </Text>
                 </View>
               </View>
@@ -200,12 +202,12 @@ export default function HomeScreen() {
                 style={styles.ctaButton}
                 icon={<Ionicons name="logo-google" size={20} color={colors.bgPrimary} />}
               >
-                Sign in with Google
+                {t.home.signIn}
               </Button>
 
               <View style={styles.divider}>
                 <View style={[styles.dividerLine, { backgroundColor: colors.border }]} />
-                <Text style={[styles.dividerText, { color: colors.textMuted }]}>or</Text>
+                <Text style={[styles.dividerText, { color: colors.textMuted }]}>{t.home.or}</Text>
                 <View style={[styles.dividerLine, { backgroundColor: colors.border }]} />
               </View>
 
@@ -214,13 +216,13 @@ export default function HomeScreen() {
                 onPress={handleLocalFile}
                 icon={<Ionicons name="folder-outline" size={20} color={colors.accent} />}
               >
-                Open Local File
+                {t.home.openLocal}
               </Button>
             </View>
 
             {/* Learn More Link */}
             <TouchableOpacity style={styles.learnMoreLink} onPress={handleOpenAbout}>
-              <Text style={[styles.learnMoreText, { color: colors.accent }]}>Learn more about MD Viewer</Text>
+              <Text style={[styles.learnMoreText, { color: colors.accent }]}>{t.home.learnMore}</Text>
               <Ionicons name="arrow-forward" size={16} color={colors.accent} />
             </TouchableOpacity>
           </View>
@@ -230,7 +232,7 @@ export default function HomeScreen() {
             <Pressable style={[styles.searchBox, { backgroundColor: colors.bgSecondary, borderColor: colors.border }]} onPress={handleOpenSearch}>
               <Ionicons name="search" size={20} color={colors.textMuted} />
               <Text style={[styles.searchPlaceholder, { color: colors.textMuted }]}>
-                Search Google Drive...
+                {t.home.searchPlaceholder}
               </Text>
               {Platform.OS === 'web' && (
                 <View style={[styles.kbd, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}>
@@ -243,9 +245,9 @@ export default function HomeScreen() {
             {recentFiles.length > 0 && (
               <View style={styles.recentSection}>
                 <View style={[styles.recentHeader, { borderBottomColor: colors.border }]}>
-                  <Text style={[styles.recentTitle, { color: colors.textSecondary }]}>Recent Files</Text>
+                  <Text style={[styles.recentTitle, { color: colors.textSecondary }]}>{t.home.recentFiles}</Text>
                   <TouchableOpacity onPress={handleClearHistory}>
-                    <Text style={[styles.clearButton, { color: colors.textMuted }]}>Clear</Text>
+                    <Text style={[styles.clearButton, { color: colors.textMuted }]}>{t.home.clear}</Text>
                   </TouchableOpacity>
                 </View>
 
@@ -301,18 +303,18 @@ export default function HomeScreen() {
             )}
             <TouchableOpacity style={styles.userMenuItem} onPress={handleLocalFile}>
               <Ionicons name="folder-outline" size={20} color={colors.textSecondary} />
-              <Text style={[styles.userMenuText, { color: colors.textPrimary }]}>Open Local File</Text>
+              <Text style={[styles.userMenuText, { color: colors.textPrimary }]}>{t.home.openLocal}</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.userMenuItem} onPress={handleOpenAbout}>
               <Ionicons name="information-circle-outline" size={20} color={colors.textSecondary} />
-              <Text style={[styles.userMenuText, { color: colors.textPrimary }]}>About MD Viewer</Text>
+              <Text style={[styles.userMenuText, { color: colors.textPrimary }]}>{t.home.about}</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.userMenuItem, styles.userMenuLogout]}
               onPress={logout}
             >
               <Ionicons name="log-out-outline" size={20} color={colors.error} />
-              <Text style={[styles.userMenuText, { color: colors.error }]}>Sign Out</Text>
+              <Text style={[styles.userMenuText, { color: colors.error }]}>{t.home.signOut}</Text>
             </TouchableOpacity>
           </View>
         </>

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -18,11 +18,12 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
-import { useGoogleAuth, useTheme } from '../src/hooks';
+import { useGoogleAuth, useTheme, useLanguage } from '../src/hooks';
 import type { DriveFile } from '../src/types';
 
 export default function SearchScreen() {
   const { colors } = useTheme();
+  const { t, language } = useLanguage();
   const {
     isLoading,
     isAuthenticated,
@@ -80,11 +81,11 @@ export default function SearchScreen() {
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
 
-    if (days > 30) return date.toLocaleDateString('en-US');
-    if (days > 0) return `${days}d ago`;
-    if (hours > 0) return `${hours}h ago`;
-    if (minutes > 0) return `${minutes}m ago`;
-    return 'Just now';
+    if (days > 30) return date.toLocaleDateString(language === 'ja' ? 'ja-JP' : 'en-US');
+    if (days > 0) return t.common.daysAgo.replace('{days}', String(days));
+    if (hours > 0) return t.common.hoursAgo.replace('{hours}', String(hours));
+    if (minutes > 0) return t.common.minutesAgo.replace('{min}', String(minutes));
+    return t.common.justNow;
   };
 
   const formatFileSize = (sizeString?: string): string => {
@@ -141,7 +142,7 @@ export default function SearchScreen() {
             <TextInput
               ref={inputRef}
               style={[styles.searchInput, { color: colors.textPrimary }]}
-              placeholder="Search Google Drive..."
+              placeholder={t.search.placeholder}
               placeholderTextColor={colors.textMuted}
               value={query}
               onChangeText={handleSearch}
@@ -162,11 +163,11 @@ export default function SearchScreen() {
           {!isAuthenticated ? (
             <View style={styles.authPrompt}>
               <Text style={[styles.authText, { color: colors.textSecondary }]}>
-                Please sign in to search{'\n'}Google Drive
+                {t.search.signInPrompt}
               </Text>
               <TouchableOpacity style={[styles.authButton, { backgroundColor: colors.accent }]} onPress={authenticate}>
                 <Ionicons name="logo-google" size={20} color={colors.bgPrimary} />
-                <Text style={[styles.authButtonText, { color: colors.bgPrimary }]}>Sign in with Google</Text>
+                <Text style={[styles.authButtonText, { color: colors.bgPrimary }]}>{t.search.signIn}</Text>
               </TouchableOpacity>
             </View>
           ) : query.length === 0 ? (
@@ -174,23 +175,23 @@ export default function SearchScreen() {
               <View style={styles.emptyIcon}>
                 <Ionicons name="search-outline" size={48} color={colors.textMuted} />
               </View>
-              <Text style={[styles.emptyTitle, { color: colors.textSecondary }]}>Search Markdown Files</Text>
+              <Text style={[styles.emptyTitle, { color: colors.textSecondary }]}>{t.search.emptyTitle}</Text>
               <Text style={[styles.emptyHint, { color: colors.textMuted }]}>
-                Type at least 2 characters to start searching
+                {t.search.emptyHint}
               </Text>
             </View>
           ) : query.length < 2 ? (
             <View style={styles.messageContainer}>
-              <Text style={[styles.messageText, { color: colors.textSecondary }]}>Type at least 2 characters</Text>
+              <Text style={[styles.messageText, { color: colors.textSecondary }]}>{t.search.minChars}</Text>
             </View>
           ) : results.length === 0 && !isLoading ? (
             <View style={styles.emptyState}>
               <View style={styles.emptyIcon}>
                 <Ionicons name="document-outline" size={48} color={colors.textMuted} />
               </View>
-              <Text style={[styles.emptyTitle, { color: colors.textSecondary }]}>No Results Found</Text>
+              <Text style={[styles.emptyTitle, { color: colors.textSecondary }]}>{t.search.noResults}</Text>
               <Text style={[styles.emptyHint, { color: colors.textMuted }]}>
-                Try searching with different keywords
+                {t.search.noResultsHint}
               </Text>
             </View>
           ) : (
@@ -203,7 +204,9 @@ export default function SearchScreen() {
               ListHeaderComponent={
                 results.length > 0 ? (
                   <Text style={[styles.resultsHeader, { color: colors.textMuted }]}>
-                    {results.length} {results.length === 1 ? 'result' : 'results'}
+                    {results.length === 1
+                      ? t.search.resultCount.replace('{count}', '1')
+                      : t.search.resultsCount.replace('{count}', String(results.length))}
                   </Text>
                 ) : null
               }

--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -15,9 +15,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
-import { Card, ThemeToggle } from '../src/components/ui';
+import { Card, ThemeToggle, LanguageToggle } from '../src/components/ui';
 import { MarkdownRenderer } from '../src/components/markdown';
-import { useGoogleAuth, useShare, useTheme } from '../src/hooks';
+import { useGoogleAuth, useShare, useTheme, useLanguage } from '../src/hooks';
 import { addFileToHistory } from '../src/services';
 
 type ViewerParams = {
@@ -29,6 +29,7 @@ type ViewerParams = {
 
 export default function ViewerScreen() {
   const { colors, mode } = useTheme();
+  const { t } = useLanguage();
   const params = useLocalSearchParams<ViewerParams>();
   const { fetchFileContent, isLoading: isAuthLoading, isAuthenticated, accessToken } = useGoogleAuth();
   const { shareContent, isProcessing } = useShare();
@@ -43,13 +44,13 @@ export default function ViewerScreen() {
         return;
       }
       if (!accessToken) {
-        setError('Authentication required. Please go back to home and sign in.');
+        setError(t.viewer.authRequired);
         setIsLoading(false);
         return;
       }
       loadFileContent();
     }
-  }, [params.id, params.source, params.content, isAuthLoading, accessToken]);
+  }, [params.id, params.source, params.content, isAuthLoading, accessToken, t.viewer.authRequired]);
 
   const loadFileContent = async () => {
     setIsLoading(true);
@@ -65,10 +66,10 @@ export default function ViewerScreen() {
           source: 'google-drive',
         });
       } else {
-        setError('Failed to load file');
+        setError(t.viewer.loadFailed);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setError(err instanceof Error ? err.message : t.viewer.errorOccurred);
     } finally {
       setIsLoading(false);
     }
@@ -106,6 +107,7 @@ export default function ViewerScreen() {
           </Text>
         </View>
         <View style={styles.headerActions}>
+          <LanguageToggle />
           <ThemeToggle />
           <TouchableOpacity
             style={[
@@ -133,7 +135,7 @@ export default function ViewerScreen() {
       {isLoading ? (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.accent} />
-          <Text style={[styles.loadingText, { color: colors.textMuted }]}>Loading...</Text>
+          <Text style={[styles.loadingText, { color: colors.textMuted }]}>{t.viewer.loading}</Text>
         </View>
       ) : error ? (
         <View style={styles.errorContainer}>
@@ -143,7 +145,7 @@ export default function ViewerScreen() {
             style={[styles.retryButton, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}
             onPress={loadFileContent}
           >
-            <Text style={[styles.retryText, { color: colors.textPrimary }]}>Retry</Text>
+            <Text style={[styles.retryText, { color: colors.textPrimary }]}>{t.viewer.retry}</Text>
           </TouchableOpacity>
         </View>
       ) : content ? (
@@ -159,7 +161,7 @@ export default function ViewerScreen() {
       ) : (
         <View style={styles.emptyContainer}>
           <Ionicons name="document-outline" size={48} color={colors.textMuted} />
-          <Text style={[styles.emptyText, { color: colors.textMuted }]}>No content</Text>
+          <Text style={[styles.emptyText, { color: colors.textMuted }]}>{t.viewer.noContent}</Text>
         </View>
       )}
     </SafeAreaView>

--- a/src/components/ui/LanguageToggle.tsx
+++ b/src/components/ui/LanguageToggle.tsx
@@ -1,0 +1,41 @@
+/**
+ * Language Toggle Button
+ */
+
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { useLanguage } from '../../hooks/useLanguage';
+import { useTheme } from '../../hooks/useTheme';
+import { borderRadius, fontSize, fontWeight, spacing } from '../../theme';
+
+export function LanguageToggle() {
+  const { language, toggleLanguage } = useLanguage();
+  const { colors } = useTheme();
+
+  return (
+    <TouchableOpacity
+      onPress={toggleLanguage}
+      style={[styles.button, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}
+      activeOpacity={0.7}
+      accessibilityLabel={language === 'en' ? 'Switch to Japanese' : 'Switch to English'}
+      accessibilityRole="button"
+    >
+      <Text style={[styles.text, { color: colors.textSecondary }]}>
+        {language === 'en' ? 'JA' : 'EN'}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.sm,
+    borderWidth: 1,
+  },
+  text: {
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.semibold,
+  },
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,3 +4,4 @@ export { LoadingSpinner } from './LoadingSpinner';
 export { Card } from './Card';
 export { FAB } from './FAB';
 export { ThemeToggle } from './ThemeToggle';
+export { LanguageToggle } from './LanguageToggle';

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,80 @@
+/**
+ * Language Context - English/Japanese language management
+ */
+
+import React, { createContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react';
+import { en, ja, type Translations } from '../i18n';
+
+export type Language = 'en' | 'ja';
+
+export interface LanguageContextValue {
+  language: Language;
+  t: Translations;
+  toggleLanguage: () => void;
+  setLanguage: (lang: Language) => void;
+}
+
+const STORAGE_KEY = 'md-viewer-language-preference';
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+interface LanguageProviderProps {
+  children: ReactNode;
+}
+
+export function LanguageProvider({ children }: LanguageProviderProps) {
+  const [language, setLanguageState] = useState<Language>('en');
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Initialize language from localStorage
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored === 'en' || stored === 'ja') {
+          setLanguageState(stored);
+        }
+      } catch (e) {
+        console.warn('Failed to read language preference:', e);
+      }
+      setIsInitialized(true);
+    }
+  }, []);
+
+  // Persist language preference
+  useEffect(() => {
+    if (isInitialized && typeof window !== 'undefined') {
+      try {
+        localStorage.setItem(STORAGE_KEY, language);
+      } catch (e) {
+        console.warn('Failed to save language preference:', e);
+      }
+    }
+  }, [language, isInitialized]);
+
+  const toggleLanguage = useCallback(() => {
+    setLanguageState((prev) => (prev === 'en' ? 'ja' : 'en'));
+  }, []);
+
+  const setLanguage = useCallback((lang: Language) => {
+    setLanguageState(lang);
+  }, []);
+
+  const t = useMemo(() => {
+    return language === 'en' ? en : ja;
+  }, [language]);
+
+  const value = useMemo(
+    () => ({
+      language,
+      t,
+      toggleLanguage,
+      setLanguage,
+    }),
+    [language, t, toggleLanguage, setLanguage]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export { LanguageContext };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,5 @@ export { useShare } from './useShare';
 export type { UseShareReturn } from './useShare';
 
 export { useTheme } from './useTheme';
+
+export { useLanguage } from './useLanguage';

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,0 +1,14 @@
+/**
+ * useLanguage hook - Access language context
+ */
+
+import { useContext } from 'react';
+import { LanguageContext, type LanguageContextValue } from '../contexts/LanguageContext';
+
+export function useLanguage(): LanguageContextValue {
+  const context = useContext(LanguageContext);
+  if (context === undefined) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,6 @@
+/**
+ * i18n - Internationalization exports
+ */
+
+export { en, type Translations } from './locales/en';
+export { ja } from './locales/ja';

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,203 @@
+/**
+ * English translations
+ */
+
+export const en = {
+  // Home Screen
+  home: {
+    welcome: 'Welcome to MD Viewer',
+    subtitle: 'A beautiful Markdown viewer for\nGoogle Drive',
+    feature: {
+      drive: {
+        title: 'Google Drive Integration',
+        desc: 'Search and open Markdown files directly from your Google Drive',
+      },
+      rendering: {
+        title: 'Beautiful Rendering',
+        desc: 'Syntax highlighting, Mermaid diagrams, and clean typography',
+      },
+      pdf: {
+        title: 'Export to PDF',
+        desc: 'Share your documents as beautifully formatted PDFs',
+      },
+    },
+    signIn: 'Sign in with Google',
+    or: 'or',
+    openLocal: 'Open Local File',
+    learnMore: 'Learn more about MD Viewer',
+    searchPlaceholder: 'Search Google Drive...',
+    recentFiles: 'Recent Files',
+    clear: 'Clear',
+    about: 'About MD Viewer',
+    signOut: 'Sign Out',
+  },
+
+  // Viewer Screen
+  viewer: {
+    loading: 'Loading...',
+    retry: 'Retry',
+    noContent: 'No content',
+    authRequired: 'Authentication required. Please go back to home and sign in.',
+    loadFailed: 'Failed to load file',
+    errorOccurred: 'An error occurred',
+  },
+
+  // Search Screen
+  search: {
+    placeholder: 'Search Google Drive...',
+    signInPrompt: 'Please sign in to search\nGoogle Drive',
+    signIn: 'Sign in with Google',
+    emptyTitle: 'Search Markdown Files',
+    emptyHint: 'Type at least 2 characters to start searching',
+    minChars: 'Type at least 2 characters',
+    noResults: 'No Results Found',
+    noResultsHint: 'Try searching with different keywords',
+    resultCount: '{count} result',
+    resultsCount: '{count} results',
+  },
+
+  // About Screen
+  about: {
+    title: 'About MD Viewer',
+    appName: 'MD Viewer',
+    version: 'Version {version}',
+    whatIs: 'What is MD Viewer?',
+    description:
+      'MD Viewer is a web application that beautifully renders Markdown files stored in your Google Drive. It provides a seamless reading experience with syntax highlighting, diagram support, and PDF export capabilities.',
+    features: 'Features',
+    feature: {
+      drive: {
+        title: 'Google Drive Integration',
+        desc: 'Connect your Google account and search for Markdown files directly from your Drive. Quick access to your documents without downloading.',
+      },
+      syntax: {
+        title: 'Syntax Highlighting',
+        desc: 'Code blocks are rendered with syntax highlighting for various programming languages including JavaScript, Python, TypeScript, and more.',
+      },
+      mermaid: {
+        title: 'Mermaid Diagrams',
+        desc: 'Create flowcharts, sequence diagrams, and other visualizations using Mermaid syntax. Diagrams are rendered automatically within your documents.',
+      },
+      pdf: {
+        title: 'PDF Export',
+        desc: 'Export your rendered Markdown documents as PDF files. Perfect for sharing documentation or creating printable versions of your notes.',
+      },
+      local: {
+        title: 'Local File Support',
+        desc: 'Open Markdown files from your local device without signing in. Great for quick previews or when working offline.',
+      },
+      recent: {
+        title: 'Recent Files',
+        desc: 'Quick access to recently viewed files. Your reading history is stored locally for convenience.',
+      },
+    },
+    supported: 'Supported Markdown Features',
+    chips: {
+      headers: 'Headers',
+      boldItalic: 'Bold / Italic',
+      lists: 'Lists',
+      tables: 'Tables',
+      codeBlocks: 'Code Blocks',
+      links: 'Links',
+      images: 'Images',
+      blockquotes: 'Blockquotes',
+      taskLists: 'Task Lists',
+      strikethrough: 'Strikethrough',
+      mermaid: 'Mermaid',
+      gfm: 'GFM',
+    },
+    privacy: 'Privacy & Security',
+    privacyDesc:
+      'MD Viewer only requests read-only access to your Google Drive files. Your documents are never stored on our servers - they are fetched directly from Google Drive and rendered in your browser. Your authentication tokens are stored securely in your browser\'s local storage.',
+    footer: 'Built with Expo and React Native Web',
+  },
+
+  // Common
+  common: {
+    justNow: 'Just now',
+    minutesAgo: '{min}m ago',
+    hoursAgo: '{hours}h ago',
+    daysAgo: '{days}d ago',
+  },
+};
+
+export type Translations = {
+  home: {
+    welcome: string;
+    subtitle: string;
+    feature: {
+      drive: { title: string; desc: string };
+      rendering: { title: string; desc: string };
+      pdf: { title: string; desc: string };
+    };
+    signIn: string;
+    or: string;
+    openLocal: string;
+    learnMore: string;
+    searchPlaceholder: string;
+    recentFiles: string;
+    clear: string;
+    about: string;
+    signOut: string;
+  };
+  viewer: {
+    loading: string;
+    retry: string;
+    noContent: string;
+    authRequired: string;
+    loadFailed: string;
+    errorOccurred: string;
+  };
+  search: {
+    placeholder: string;
+    signInPrompt: string;
+    signIn: string;
+    emptyTitle: string;
+    emptyHint: string;
+    minChars: string;
+    noResults: string;
+    noResultsHint: string;
+    resultCount: string;
+    resultsCount: string;
+  };
+  about: {
+    title: string;
+    appName: string;
+    version: string;
+    whatIs: string;
+    description: string;
+    features: string;
+    feature: {
+      drive: { title: string; desc: string };
+      syntax: { title: string; desc: string };
+      mermaid: { title: string; desc: string };
+      pdf: { title: string; desc: string };
+      local: { title: string; desc: string };
+      recent: { title: string; desc: string };
+    };
+    supported: string;
+    chips: {
+      headers: string;
+      boldItalic: string;
+      lists: string;
+      tables: string;
+      codeBlocks: string;
+      links: string;
+      images: string;
+      blockquotes: string;
+      taskLists: string;
+      strikethrough: string;
+      mermaid: string;
+      gfm: string;
+    };
+    privacy: string;
+    privacyDesc: string;
+    footer: string;
+  };
+  common: {
+    justNow: string;
+    minutesAgo: string;
+    hoursAgo: string;
+    daysAgo: string;
+  };
+};

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1,0 +1,124 @@
+/**
+ * Japanese translations
+ */
+
+import type { Translations } from './en';
+
+export const ja: Translations = {
+  // Home Screen
+  home: {
+    welcome: 'MD Viewerへようこそ',
+    subtitle: 'Google Drive用\nMarkdownビューア',
+    feature: {
+      drive: {
+        title: 'Google Drive連携',
+        desc: 'Google Driveから直接Markdownファイルを検索・表示',
+      },
+      rendering: {
+        title: '美しいレンダリング',
+        desc: 'シンタックスハイライト、Mermaid図表、美しいタイポグラフィ',
+      },
+      pdf: {
+        title: 'PDF出力',
+        desc: 'ドキュメントを美しいPDFとして共有',
+      },
+    },
+    signIn: 'Googleでサインイン',
+    or: 'または',
+    openLocal: 'ローカルファイルを開く',
+    learnMore: 'MD Viewerについて詳しく',
+    searchPlaceholder: 'Google Driveを検索...',
+    recentFiles: '最近のファイル',
+    clear: 'クリア',
+    about: 'MD Viewerについて',
+    signOut: 'サインアウト',
+  },
+
+  // Viewer Screen
+  viewer: {
+    loading: '読み込み中...',
+    retry: '再試行',
+    noContent: 'コンテンツがありません',
+    authRequired: '認証が必要です。ホームに戻ってサインインしてください。',
+    loadFailed: 'ファイルの読み込みに失敗しました',
+    errorOccurred: 'エラーが発生しました',
+  },
+
+  // Search Screen
+  search: {
+    placeholder: 'Google Driveを検索...',
+    signInPrompt: 'Google Driveを検索するには\nサインインしてください',
+    signIn: 'Googleでサインイン',
+    emptyTitle: 'Markdownファイルを検索',
+    emptyHint: '2文字以上入力して検索を開始',
+    minChars: '2文字以上入力してください',
+    noResults: '結果が見つかりません',
+    noResultsHint: '別のキーワードで検索してみてください',
+    resultCount: '{count}件',
+    resultsCount: '{count}件',
+  },
+
+  // About Screen
+  about: {
+    title: 'MD Viewerについて',
+    appName: 'MD Viewer',
+    version: 'バージョン {version}',
+    whatIs: 'MD Viewerとは？',
+    description:
+      'MD ViewerはGoogle Driveに保存されたMarkdownファイルを美しく表示するWebアプリケーションです。シンタックスハイライト、図表サポート、PDF出力機能により、快適な閲覧体験を提供します。',
+    features: '機能',
+    feature: {
+      drive: {
+        title: 'Google Drive連携',
+        desc: 'Googleアカウントを接続して、DriveからMarkdownファイルを直接検索。ダウンロード不要でドキュメントにすばやくアクセス。',
+      },
+      syntax: {
+        title: 'シンタックスハイライト',
+        desc: 'JavaScript、Python、TypeScriptなど、様々なプログラミング言語のコードブロックをシンタックスハイライト付きで表示。',
+      },
+      mermaid: {
+        title: 'Mermaid図表',
+        desc: 'Mermaid記法を使用してフローチャート、シーケンス図などを作成。ドキュメント内で自動的にレンダリング。',
+      },
+      pdf: {
+        title: 'PDF出力',
+        desc: 'レンダリングされたMarkdownドキュメントをPDFファイルとして出力。ドキュメント共有や印刷用に最適。',
+      },
+      local: {
+        title: 'ローカルファイル対応',
+        desc: 'サインインなしでローカルデバイスからMarkdownファイルを開けます。クイックプレビューやオフライン作業に便利。',
+      },
+      recent: {
+        title: '最近のファイル',
+        desc: '最近閲覧したファイルにすばやくアクセス。閲覧履歴はローカルに保存されます。',
+      },
+    },
+    supported: '対応Markdown機能',
+    chips: {
+      headers: '見出し',
+      boldItalic: '太字 / 斜体',
+      lists: 'リスト',
+      tables: 'テーブル',
+      codeBlocks: 'コードブロック',
+      links: 'リンク',
+      images: '画像',
+      blockquotes: '引用',
+      taskLists: 'タスクリスト',
+      strikethrough: '取り消し線',
+      mermaid: 'Mermaid',
+      gfm: 'GFM',
+    },
+    privacy: 'プライバシーとセキュリティ',
+    privacyDesc:
+      'MD ViewerはGoogle Driveファイルへの読み取り専用アクセスのみを要求します。ドキュメントは当社のサーバーに保存されることはなく、Google Driveから直接取得してブラウザでレンダリングされます。認証トークンはブラウザのローカルストレージに安全に保存されます。',
+    footer: 'Expo と React Native Web で構築',
+  },
+
+  // Common
+  common: {
+    justNow: 'たった今',
+    minutesAgo: '{min}分前',
+    hoursAgo: '{hours}時間前',
+    daysAgo: '{days}日前',
+  },
+};


### PR DESCRIPTION
## Summary

- Add LanguageContext with localStorage persistence for user preference
- Add LanguageToggle component (EN/JA button) in header next to ThemeToggle
- Create translation files for English and Japanese
- Update all screens with translated text strings
- Add locale-aware date formatting (en-US / ja-JP)

## New Files
- `src/i18n/locales/en.ts` - English translations
- `src/i18n/locales/ja.ts` - Japanese translations
- `src/i18n/index.ts` - i18n exports
- `src/contexts/LanguageContext.tsx` - Language state management
- `src/hooks/useLanguage.ts` - Hook for accessing language context
- `src/components/ui/LanguageToggle.tsx` - Toggle button component

## Updated Files
- `app/_layout.tsx` - Wrapped with LanguageProvider
- `app/index.tsx`, `app/viewer.tsx`, `app/search.tsx`, `app/about.tsx` - All text translated
- `src/hooks/index.ts`, `src/components/ui/index.ts` - Export new components

## Test plan
- [ ] Verify language toggle in header works on all screens
- [ ] Verify language persists after page reload
- [ ] Verify all text is correctly translated when switching language
- [ ] Verify date formatting changes with locale (en-US vs ja-JP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)