### PR TITLE
feat: Add license pages and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 luckypool
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 # MD Viewer
 
-Google Drive やローカルに保存された Markdown ファイルをプレビューするアプリです。
+Google Drive やローカルに保存された Markdown ファイルをプレビューする Web アプリです。
 
 [![Expo](https://img.shields.io/badge/Expo-54-000020?logo=expo)](https://expo.dev/)
-[![React Native](https://img.shields.io/badge/React%20Native-0.81-61DAFB?logo=react)](https://reactnative.dev/)
+[![React Native Web](https://img.shields.io/badge/React%20Native%20Web-0.81-61DAFB?logo=react)](https://necolas.github.io/react-native-web/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript)](https://www.typescriptlang.org/)
-
-**Web** | **iOS** | **Android**
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 </div>
 
@@ -22,10 +21,12 @@ Google Drive やローカルに保存された Markdown ファイルをプレビ
   - テーブル
   - タスクリスト
   - 打ち消し線
-- 📈 Mermaid ダイアグラム対応（Web）
-- 📄 PDF 出力・共有機能
+- 📈 Mermaid ダイアグラム対応
+- 📄 PDF 出力機能
 - 🕐 最近使ったファイルの履歴
-- ⌨️ キーボードショートカット（`⌘K` / `Ctrl+K` で検索、Web のみ）
+- ⌨️ キーボードショートカット（`⌘K` / `Ctrl+K` で検索）
+- 🌙 ダークモード / ライトモード切り替え
+- 🌐 日本語 / 英語 切り替え
 
 ## セットアップ
 
@@ -46,8 +47,6 @@ npm install
 
 ### 3. OAuth 2.0 クライアント ID の作成
 
-#### Web 用
-
 1. **APIs & Services** → **Credentials** に移動
 2. **Create Credentials** → **OAuth client ID** を選択
 3. **Application type**: Web application
@@ -55,13 +54,6 @@ npm install
    - `http://localhost:8081`（開発用）
    - 本番ドメイン（デプロイ後）
 5. **Create** をクリックし、**Client ID** を控える
-
-#### iOS / Android 用（オプション）
-
-1. **Create Credentials** → **OAuth client ID** を選択
-2. **Application type**: iOS または Android
-3. Bundle ID / Package name を入力
-4. **Create** をクリックし、**Client ID** を控える
 
 ### 4. API キーの作成
 
@@ -85,52 +77,48 @@ npm install
 ```bash
 EXPO_PUBLIC_GOOGLE_API_KEY=your_api_key_here
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=your_web_client_id_here
-EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=your_ios_client_id_here      # iOS 用（オプション）
-EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=your_android_client_id  # Android 用（オプション）
 ```
 
 ### 7. 開発サーバーの起動
 
 ```bash
-# 全プラットフォーム
+# Web 開発サーバー
 npm start
-
-# Web のみ
+# または
 npm run web
-
-# iOS のみ
-npm run ios
-
-# Android のみ
-npm run android
 ```
 
 ## 使い方
 
 ### Google Drive から開く
 
-1. 「Google でログイン」ボタンをタップ
+1. 「Google でサインイン」ボタンをクリック
 2. Google アカウントでログイン
-3. 検索ボックスをタップ（Web: `⌘K` / `Ctrl+K`）
+3. 検索ボックスをクリック（または `⌘K` / `Ctrl+K`）
 4. ファイル名を入力して検索
 5. ファイルを選択するとプレビューが表示されます
 
 ### ローカルファイルを開く
 
-1. 「ローカルファイルを開く」ボタンをタップ
+1. 「ローカルファイルを開く」ボタンをクリック
 2. Markdown ファイル (`.md`) を選択
 3. プレビューが表示されます
 
 ### 最近使ったファイル
 
 ログイン後、ホーム画面に最近開いたファイルの履歴が表示されます。
-タップするだけで素早くファイルを開くことができます。
+クリックするだけで素早くファイルを開くことができます。
 
-### PDF として出力・共有
+### テーマ・言語の切り替え
 
-1. Markdown ファイルを開いた状態で、共有ボタンをタップ
-2. iOS / Android では共有シートが表示されます
-3. Web では PDF ファイルがダウンロードされます
+ヘッダー右側のアイコンから切り替え可能です:
+- 🌙/☀️ ダークモード / ライトモード
+- EN/JA 英語 / 日本語
+
+### PDF として出力
+
+1. Markdown ファイルを開いた状態で、共有ボタンをクリック
+2. PDF ファイルがダウンロードされます
 
 ## プロジェクト構造
 
@@ -140,17 +128,26 @@ md-viewer/
 │   ├── _layout.tsx           # ルートレイアウト
 │   ├── index.tsx             # ホーム画面
 │   ├── viewer.tsx            # Markdown 表示
-│   └── search.tsx            # Google Drive 検索
+│   ├── search.tsx            # Google Drive 検索
+│   ├── about.tsx             # アプリについて
+│   └── license.tsx           # ライセンス表示
 ├── src/
 │   ├── components/
 │   │   ├── ui/               # 共通 UI コンポーネント
-│   │   └── markdown/         # Markdown レンダラー（プラットフォーム別）
-│   ├── hooks/                # カスタムフック（プラットフォーム別）
-│   │   ├── useGoogleAuth     # Google OAuth
+│   │   └── markdown/         # Markdown レンダラー
+│   ├── contexts/             # React Context
+│   │   ├── ThemeContext      # テーマ管理
+│   │   └── LanguageContext   # 言語管理
+│   ├── hooks/                # カスタムフック
+│   │   ├── useGoogleAuth     # Google OAuth (GIS)
 │   │   ├── useFilePicker     # ファイル選択
+│   │   ├── useTheme          # テーマフック
+│   │   ├── useLanguage       # 言語フック
 │   │   └── useShare          # PDF 出力・共有
+│   ├── i18n/                 # 国際化
+│   │   └── locales/          # 翻訳ファイル（en, ja）
 │   ├── services/             # サービス層
-│   │   ├── storage.ts        # ストレージ抽象化
+│   │   ├── storage.ts        # localStorage ラッパー
 │   │   ├── fileHistory.ts    # ファイル履歴
 │   │   └── googleDrive.ts    # Drive API
 │   ├── theme/                # テーマ定義
@@ -160,41 +157,30 @@ md-viewer/
 └── package.json
 ```
 
-## プラットフォーム別実装
-
-ファイル拡張子でプラットフォームを自動分岐:
-
-- `*.web.ts` / `*.web.tsx` - Web 専用
-- `*.native.ts` / `*.native.tsx` - iOS / Android 専用
-- `*.ts` / `*.tsx` - 共通エントリポイント
-
 ## 技術スタック
 
-- **Expo SDK 54** + **React Native 0.81**
+- **Expo SDK 54** + **React Native Web**
 - **Expo Router 6** - ファイルベースルーティング
 - **TypeScript 5.9**
-- **react-markdown** / **react-native-markdown-display** - Markdown レンダリング
-- **expo-auth-session** - Native OAuth
-- **expo-document-picker** - ファイル選択
-- **expo-print** / **expo-sharing** - PDF 出力・共有
+- **react-markdown** - Markdown レンダリング
+- **react-syntax-highlighter** - コードハイライト
+- **mermaid** - ダイアグラム表示
+- **html2pdf.js** - PDF 出力
+- **Google Identity Services (GIS)** - OAuth 認証
 - **Google Drive API** - ファイル検索・取得
 
 ## デプロイ
 
-### Web（Vercel）
+### Vercel
 
 ```bash
-npx expo export -p web
+npm run build
 ```
 
 `vercel.json` が設定済みです。
 
-### iOS / Android
-
-```bash
-npx eas build
-```
-
 ## ライセンス
 
-MIT
+[MIT License](./LICENSE)
+
+Copyright (c) 2025 luckypool

--- a/app/about.tsx
+++ b/app/about.tsx
@@ -176,6 +176,30 @@ export default function AboutScreen() {
           </Text>
         </View>
 
+        {/* License */}
+        <View style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>{t.about.license}</Text>
+          <Text style={[styles.sectionText, { color: colors.textSecondary }]}>
+            {t.about.licenseDesc}
+          </Text>
+          <View style={styles.licenseButtons}>
+            <TouchableOpacity
+              style={[styles.licenseButton, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}
+              onPress={() => router.push('/license')}
+            >
+              <Ionicons name="document-text-outline" size={18} color={colors.textSecondary} />
+              <Text style={[styles.licenseButtonText, { color: colors.textSecondary }]}>{t.about.viewLicense}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.licenseButton, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}
+              onPress={() => router.push('/third-party-licenses')}
+            >
+              <Ionicons name="library-outline" size={18} color={colors.textSecondary} />
+              <Text style={[styles.licenseButtonText, { color: colors.textSecondary }]}>{t.about.viewThirdPartyLicenses}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
         {/* Footer */}
         <View style={[styles.footer, { borderTopColor: colors.border }]}>
           <Text style={[styles.footerText, { color: colors.textMuted }]}>
@@ -301,6 +325,27 @@ const styles = StyleSheet.create({
   },
   chipText: {
     fontSize: fontSize.sm,
+  },
+
+  // License Buttons
+  licenseButtons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  licenseButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  licenseButtonText: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
   },
 
   // Footer

--- a/app/license.tsx
+++ b/app/license.tsx
@@ -1,0 +1,126 @@
+/**
+ * MD Viewer - License Screen
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
+import { useTheme, useLanguage } from '../src/hooks';
+import { ThemeToggle, LanguageToggle } from '../src/components/ui';
+
+const LICENSE_TEXT = `MIT License
+
+Copyright (c) 2025 luckypool
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.`;
+
+export default function LicenseScreen() {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: colors.border, backgroundColor: colors.bgSecondary }]}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t.about.license}</Text>
+        <View style={styles.headerActions}>
+          <LanguageToggle />
+          <ThemeToggle />
+        </View>
+      </View>
+
+      <ScrollView
+        style={styles.content}
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={[styles.licenseCard, { backgroundColor: colors.bgCard, borderColor: colors.border }]}>
+          <Text style={[styles.licenseText, { color: colors.textSecondary }]}>
+            {LICENSE_TEXT}
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    textAlign: 'center',
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  content: {
+    flex: 1,
+  },
+  contentContainer: {
+    padding: spacing.xl,
+    maxWidth: 700,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  licenseCard: {
+    borderWidth: 1,
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+  },
+  licenseText: {
+    fontSize: fontSize.sm,
+    lineHeight: fontSize.sm * 1.8,
+    fontFamily: 'monospace',
+  },
+});

--- a/app/third-party-licenses.tsx
+++ b/app/third-party-licenses.tsx
@@ -1,0 +1,305 @@
+/**
+ * MD Viewer - Third-Party Licenses Screen
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Linking,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
+import { useTheme, useLanguage } from '../src/hooks';
+import { ThemeToggle, LanguageToggle } from '../src/components/ui';
+
+interface LibraryInfo {
+  name: string;
+  version: string;
+  license: string;
+  url: string;
+  author?: string;
+}
+
+const LIBRARIES: LibraryInfo[] = [
+  {
+    name: 'React',
+    version: '19.1.0',
+    license: 'MIT',
+    url: 'https://github.com/facebook/react',
+    author: 'Meta Platforms, Inc.',
+  },
+  {
+    name: 'React Native',
+    version: '0.81.5',
+    license: 'MIT',
+    url: 'https://github.com/facebook/react-native',
+    author: 'Meta Platforms, Inc.',
+  },
+  {
+    name: 'React Native Web',
+    version: '0.21.0',
+    license: 'MIT',
+    url: 'https://github.com/necolas/react-native-web',
+    author: 'Nicolas Gallagher',
+  },
+  {
+    name: 'Expo',
+    version: '54.0.32',
+    license: 'MIT',
+    url: 'https://github.com/expo/expo',
+    author: 'Expo',
+  },
+  {
+    name: 'Expo Router',
+    version: '6.0.22',
+    license: 'MIT',
+    url: 'https://github.com/expo/expo/tree/main/packages/expo-router',
+    author: 'Expo',
+  },
+  {
+    name: '@expo/vector-icons',
+    version: '15.0.3',
+    license: 'MIT',
+    url: 'https://github.com/expo/vector-icons',
+    author: 'Expo',
+  },
+  {
+    name: '@react-navigation/native',
+    version: '7.1.8',
+    license: 'MIT',
+    url: 'https://github.com/react-navigation/react-navigation',
+    author: 'React Navigation Contributors',
+  },
+  {
+    name: 'react-markdown',
+    version: '10.1.0',
+    license: 'MIT',
+    url: 'https://github.com/remarkjs/react-markdown',
+    author: 'Espen Hovlandsdal',
+  },
+  {
+    name: 'remark-gfm',
+    version: '4.0.1',
+    license: 'MIT',
+    url: 'https://github.com/remarkjs/remark-gfm',
+    author: 'Titus Wormer',
+  },
+  {
+    name: 'react-syntax-highlighter',
+    version: '16.1.0',
+    license: 'MIT',
+    url: 'https://github.com/react-syntax-highlighter/react-syntax-highlighter',
+    author: 'Conor Hastings',
+  },
+  {
+    name: 'Mermaid',
+    version: '11.12.2',
+    license: 'MIT',
+    url: 'https://github.com/mermaid-js/mermaid',
+    author: 'Knut Sveidqvist',
+  },
+  {
+    name: 'html2pdf.js',
+    version: '0.14.0',
+    license: 'MIT',
+    url: 'https://github.com/eKoopmans/html2pdf.js',
+    author: 'Erik Koopmans',
+  },
+  {
+    name: 'react-native-safe-area-context',
+    version: '5.6.0',
+    license: 'MIT',
+    url: 'https://github.com/th3rdwave/react-native-safe-area-context',
+    author: 'Janic Duplessis',
+  },
+  {
+    name: 'react-native-screens',
+    version: '4.16.0',
+    license: 'MIT',
+    url: 'https://github.com/software-mansion/react-native-screens',
+    author: 'Software Mansion',
+  },
+];
+
+export default function ThirdPartyLicensesScreen() {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  const handleOpenUrl = (url: string) => {
+    Linking.openURL(url);
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: colors.border, backgroundColor: colors.bgSecondary }]}>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t.about.thirdPartyLicenses}</Text>
+        <View style={styles.headerActions}>
+          <LanguageToggle />
+          <ThemeToggle />
+        </View>
+      </View>
+
+      <ScrollView
+        style={styles.content}
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={[styles.description, { color: colors.textSecondary }]}>
+          {t.about.thirdPartyDesc}
+        </Text>
+
+        <View style={styles.libraryList}>
+          {LIBRARIES.map((lib) => (
+            <TouchableOpacity
+              key={lib.name}
+              style={[styles.libraryCard, { backgroundColor: colors.bgCard, borderColor: colors.border }]}
+              onPress={() => handleOpenUrl(lib.url)}
+              activeOpacity={0.7}
+            >
+              <View style={styles.libraryHeader}>
+                <Text style={[styles.libraryName, { color: colors.textPrimary }]}>{lib.name}</Text>
+                <View style={[styles.licenseBadge, { backgroundColor: colors.accentMuted }]}>
+                  <Text style={[styles.licenseText, { color: colors.accent }]}>{lib.license}</Text>
+                </View>
+              </View>
+              <Text style={[styles.libraryVersion, { color: colors.textMuted }]}>v{lib.version}</Text>
+              {lib.author && (
+                <Text style={[styles.libraryAuthor, { color: colors.textSecondary }]}>{lib.author}</Text>
+              )}
+              <View style={styles.linkRow}>
+                <Ionicons name="open-outline" size={14} color={colors.accent} />
+                <Text style={[styles.linkText, { color: colors.accent }]}>View on GitHub</Text>
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={[styles.mitNotice, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}>
+          <Text style={[styles.mitNoticeTitle, { color: colors.textPrimary }]}>MIT License</Text>
+          <Text style={[styles.mitNoticeText, { color: colors.textSecondary }]}>
+            Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:{'\n\n'}
+            The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.{'\n\n'}
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    textAlign: 'center',
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  content: {
+    flex: 1,
+  },
+  contentContainer: {
+    padding: spacing.xl,
+    maxWidth: 700,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  description: {
+    fontSize: fontSize.base,
+    lineHeight: fontSize.base * 1.6,
+    marginBottom: spacing.xl,
+  },
+  libraryList: {
+    gap: spacing.md,
+  },
+  libraryCard: {
+    borderWidth: 1,
+    borderRadius: borderRadius.lg,
+    padding: spacing.md,
+  },
+  libraryHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs,
+  },
+  libraryName: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.semibold,
+    flex: 1,
+  },
+  licenseBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.sm,
+  },
+  licenseText: {
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.medium,
+  },
+  libraryVersion: {
+    fontSize: fontSize.sm,
+    marginBottom: spacing.xs,
+  },
+  libraryAuthor: {
+    fontSize: fontSize.sm,
+    marginBottom: spacing.sm,
+  },
+  linkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  linkText: {
+    fontSize: fontSize.sm,
+  },
+  mitNotice: {
+    marginTop: spacing.xl,
+    borderWidth: 1,
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+  },
+  mitNoticeTitle: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.semibold,
+    marginBottom: spacing.md,
+  },
+  mitNoticeText: {
+    fontSize: fontSize.sm,
+    lineHeight: fontSize.sm * 1.6,
+  },
+});

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -109,6 +109,12 @@ export const en = {
     privacy: 'Privacy & Security',
     privacyDesc:
       'MD Viewer only requests read-only access to your Google Drive files. Your documents are never stored on our servers - they are fetched directly from Google Drive and rendered in your browser. Your authentication tokens are stored securely in your browser\'s local storage.',
+    license: 'License',
+    licenseDesc: 'MD Viewer is open source software released under the MIT License.',
+    viewLicense: 'View License',
+    thirdPartyLicenses: 'Third-Party Licenses',
+    thirdPartyDesc: 'This application uses the following open source libraries.',
+    viewThirdPartyLicenses: 'View Third-Party Licenses',
     footer: 'Built with Expo and React Native Web',
   },
 
@@ -192,6 +198,12 @@ export type Translations = {
     };
     privacy: string;
     privacyDesc: string;
+    license: string;
+    licenseDesc: string;
+    viewLicense: string;
+    thirdPartyLicenses: string;
+    thirdPartyDesc: string;
+    viewThirdPartyLicenses: string;
     footer: string;
   };
   common: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -111,6 +111,12 @@ export const ja: Translations = {
     privacy: 'プライバシーとセキュリティ',
     privacyDesc:
       'MD ViewerはGoogle Driveファイルへの読み取り専用アクセスのみを要求します。ドキュメントは当社のサーバーに保存されることはなく、Google Driveから直接取得してブラウザでレンダリングされます。認証トークンはブラウザのローカルストレージに安全に保存されます。',
+    license: 'ライセンス',
+    licenseDesc: 'MD ViewerはMITライセンスの下で公開されているオープンソースソフトウェアです。',
+    viewLicense: 'ライセンスを見る',
+    thirdPartyLicenses: 'サードパーティライセンス',
+    thirdPartyDesc: 'このアプリケーションは以下のオープンソースライブラリを使用しています。',
+    viewThirdPartyLicenses: 'サードパーティライセンスを見る',
     footer: 'Expo と React Native Web で構築',
   },
 


### PR DESCRIPTION
## Summary
- MITライセンスファイルを追加
- `/license` ページでアプリのライセンスを表示
- `/third-party-licenses` ページで使用している14のOSSライブラリのライセンス一覧を表示
- AboutページにライセンスページへのリンクUIを追加
- i18n対応（日本語/英語）
- READMEを現在のWeb専用機能に合わせて更新

## Changes
- `LICENSE` - MIT License file
- `app/license.tsx` - License display page
- `app/third-party-licenses.tsx` - Third-party licenses page (14 libraries)
- `app/about.tsx` - Added license section with links
- `src/i18n/locales/en.ts` / `ja.ts` - Added license-related translations
- `README.md` - Updated to reflect current features

## Test plan
- [ ] `/about` ページからライセンスページへ遷移できる
- [ ] `/license` ページでMITライセンスが表示される
- [ ] `/third-party-licenses` ページでライブラリ一覧が表示される
- [ ] 各ライブラリのGitHubリンクが機能する
- [ ] 日本語/英語の切り替えが正しく動作する
- [ ] ダークモード/ライトモードで正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)