### PR TITLE
feat: Add font size and font family settings

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import { Stack } from 'expo-router';
 import { View, StyleSheet } from 'react-native';
 import { ThemeProvider } from '../src/contexts/ThemeContext';
 import { LanguageProvider } from '../src/contexts/LanguageContext';
+import { FontSettingsProvider } from '../src/contexts/FontSettingsContext';
 import { useTheme } from '../src/hooks';
 
 export { ErrorBoundary } from 'expo-router';
@@ -49,7 +50,9 @@ export default function RootLayout() {
   return (
     <ThemeProvider>
       <LanguageProvider>
-        <RootLayoutContent />
+        <FontSettingsProvider>
+          <RootLayoutContent />
+        </FontSettingsProvider>
       </LanguageProvider>
     </ThemeProvider>
   );

--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -15,10 +15,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
-import { Card, ThemeToggle, LanguageToggle } from '../src/components/ui';
+import { Card, ThemeToggle, LanguageToggle, FontSettingsPanel } from '../src/components/ui';
 import { MarkdownRenderer } from '../src/components/markdown';
 import { useGoogleAuth, useShare, useTheme, useLanguage } from '../src/hooks';
 import { addFileToHistory } from '../src/services';
+import { IconButton } from '../src/components/ui';
 
 type ViewerParams = {
   id: string;
@@ -37,6 +38,7 @@ export default function ViewerScreen() {
   const [content, setContent] = useState<string | null>(params.content || null);
   const [isLoading, setIsLoading] = useState(!params.content);
   const [error, setError] = useState<string | null>(null);
+  const [showFontSettings, setShowFontSettings] = useState(false);
 
   useEffect(() => {
     if (params.source === 'google-drive' && !params.content) {
@@ -107,6 +109,12 @@ export default function ViewerScreen() {
           </Text>
         </View>
         <View style={styles.headerActions}>
+          <TouchableOpacity
+            style={[styles.settingsButton, { backgroundColor: colors.bgTertiary }]}
+            onPress={() => setShowFontSettings(true)}
+          >
+            <Ionicons name="text-outline" size={18} color={colors.textSecondary} />
+          </TouchableOpacity>
           <LanguageToggle />
           <ThemeToggle />
           <TouchableOpacity
@@ -164,6 +172,12 @@ export default function ViewerScreen() {
           <Text style={[styles.emptyText, { color: colors.textMuted }]}>{t.viewer.noContent}</Text>
         </View>
       )}
+
+      {/* Font Settings Panel */}
+      <FontSettingsPanel
+        visible={showFontSettings}
+        onClose={() => setShowFontSettings(false)}
+      />
     </SafeAreaView>
   );
 }
@@ -201,6 +215,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
+  },
+  settingsButton: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   pdfButton: {
     flexDirection: 'row',

--- a/src/components/markdown/MarkdownRenderer.web.tsx
+++ b/src/components/markdown/MarkdownRenderer.web.tsx
@@ -14,7 +14,9 @@ import type { Components } from 'react-markdown';
 import type { MarkdownRendererProps } from '../../types/markdown';
 import { spacing, borderRadius, fontSize } from '../../theme';
 import { useTheme } from '../../hooks/useTheme';
+import { useFontSettings, fontSizeMultipliers, fontFamilyStacks } from '../../contexts/FontSettingsContext';
 import type { ThemeMode, ThemeColors } from '../../contexts/ThemeContext';
+import type { FontSettings } from '../../contexts/FontSettingsContext';
 
 // Initialize Mermaid with a theme
 const initializeMermaid = (mode: ThemeMode) => {
@@ -162,11 +164,17 @@ const githubLightTheme: { [key: string]: React.CSSProperties } = {
   important: { color: '#cf222e', fontWeight: 'bold' },
 };
 
-// Generate CSS styles based on theme
-const generateWebStyles = (colors: ThemeColors, isDark: boolean) => `
+// Generate CSS styles based on theme and font settings
+const generateWebStyles = (colors: ThemeColors, isDark: boolean, fontSettings: FontSettings) => {
+  const multiplier = fontSizeMultipliers[fontSettings.fontSize];
+  const fontStack = fontFamilyStacks[fontSettings.fontFamily];
+  const baseFontSize = Math.round(fontSize.base * multiplier);
+
+  return `
   .markdown-content {
     color: ${colors.textSecondary};
-    font-size: ${fontSize.base}px;
+    font-size: ${baseFontSize}px;
+    font-family: ${fontStack};
     line-height: 1.6;
     word-wrap: break-word;
   }
@@ -185,19 +193,19 @@ const generateWebStyles = (colors: ThemeColors, isDark: boolean) => `
   }
 
   .markdown-content h1 {
-    font-size: ${fontSize['3xl']}px;
+    font-size: ${Math.round(fontSize['3xl'] * multiplier)}px;
     padding-bottom: ${spacing.sm}px;
     border-bottom: 2px solid ${colors.borderLight};
   }
 
   .markdown-content h2 {
-    font-size: ${fontSize['2xl']}px;
+    font-size: ${Math.round(fontSize['2xl'] * multiplier)}px;
     padding-bottom: ${spacing.xs}px;
     border-bottom: 1px solid ${colors.border};
   }
 
-  .markdown-content h3 { font-size: ${fontSize.xl}px; }
-  .markdown-content h4 { font-size: ${fontSize.lg}px; }
+  .markdown-content h3 { font-size: ${Math.round(fontSize.xl * multiplier)}px; }
+  .markdown-content h4 { font-size: ${Math.round(fontSize.lg * multiplier)}px; }
 
   .markdown-content p {
     margin-bottom: ${spacing.md}px;
@@ -367,6 +375,7 @@ const generateWebStyles = (colors: ThemeColors, isDark: boolean) => `
     font-size: ${fontSize.sm}px;
   }
 `;
+};
 
 interface ExtendedMarkdownRendererProps extends MarkdownRendererProps {
   themeMode?: ThemeMode;
@@ -374,10 +383,11 @@ interface ExtendedMarkdownRendererProps extends MarkdownRendererProps {
 
 export function MarkdownRenderer({ content, onLinkPress, themeMode: propThemeMode }: ExtendedMarkdownRendererProps) {
   const { colors, mode: contextMode } = useTheme();
+  const { settings: fontSettings } = useFontSettings();
   const themeMode = propThemeMode ?? contextMode;
   const isDark = themeMode === 'dark';
 
-  const webStyles = useMemo(() => generateWebStyles(colors, isDark), [colors, isDark]);
+  const webStyles = useMemo(() => generateWebStyles(colors, isDark, fontSettings), [colors, isDark, fontSettings]);
   const syntaxTheme = isDark ? githubDarkTheme : githubLightTheme;
   const codeBlockBg = isDark ? '#161b22' : '#f6f8fa';
 

--- a/src/components/ui/FontSettingsPanel.tsx
+++ b/src/components/ui/FontSettingsPanel.tsx
@@ -1,0 +1,217 @@
+/**
+ * Font Settings Panel
+ * UI for adjusting font size and family
+ */
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Modal, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { spacing, borderRadius, fontSize, fontWeight } from '../../theme';
+import { useTheme } from '../../hooks/useTheme';
+import { useLanguage } from '../../hooks/useLanguage';
+import { useFontSettings, FontSize, FontFamily } from '../../contexts/FontSettingsContext';
+
+interface FontSettingsPanelProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+const fontSizeOptions: { value: FontSize; labelKey: 'small' | 'medium' | 'large' }[] = [
+  { value: 'small', labelKey: 'small' },
+  { value: 'medium', labelKey: 'medium' },
+  { value: 'large', labelKey: 'large' },
+];
+
+const fontFamilyOptions: { value: FontFamily; labelKey: 'system' | 'serif' | 'sansSerif' }[] = [
+  { value: 'system', labelKey: 'system' },
+  { value: 'serif', labelKey: 'serif' },
+  { value: 'sans-serif', labelKey: 'sansSerif' },
+];
+
+export function FontSettingsPanel({ visible, onClose }: FontSettingsPanelProps) {
+  const { colors } = useTheme();
+  const { t } = useLanguage();
+  const { settings, setFontSize, setFontFamily } = useFontSettings();
+
+  const fontSizeLabels: Record<'small' | 'medium' | 'large', string> = {
+    small: t.fontSettings.small,
+    medium: t.fontSettings.medium,
+    large: t.fontSettings.large,
+  };
+
+  const fontFamilyLabels: Record<'system' | 'serif' | 'sansSerif', string> = {
+    system: t.fontSettings.system,
+    serif: t.fontSettings.serif,
+    sansSerif: t.fontSettings.sansSerif,
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Pressable
+          style={[styles.panel, { backgroundColor: colors.bgSecondary, borderColor: colors.border }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <View style={[styles.header, { borderBottomColor: colors.border }]}>
+            <Text style={[styles.title, { color: colors.textPrimary }]}>
+              {t.fontSettings.title}
+            </Text>
+            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+              <Ionicons name="close" size={24} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Font Size */}
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+              {t.fontSettings.fontSize}
+            </Text>
+            <View style={styles.optionGroup}>
+              {fontSizeOptions.map(option => (
+                <TouchableOpacity
+                  key={option.value}
+                  style={[
+                    styles.option,
+                    {
+                      backgroundColor: settings.fontSize === option.value ? colors.accentMuted : colors.bgTertiary,
+                      borderColor: settings.fontSize === option.value ? colors.accent : colors.border,
+                    }
+                  ]}
+                  onPress={() => setFontSize(option.value)}
+                >
+                  <Text style={[
+                    styles.optionText,
+                    {
+                      color: settings.fontSize === option.value ? colors.accent : colors.textSecondary,
+                      fontWeight: settings.fontSize === option.value ? '600' : '400',
+                    }
+                  ]}>
+                    {fontSizeLabels[option.labelKey]}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Font Family */}
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
+              {t.fontSettings.fontFamily}
+            </Text>
+            <View style={styles.optionGroup}>
+              {fontFamilyOptions.map(option => (
+                <TouchableOpacity
+                  key={option.value}
+                  style={[
+                    styles.option,
+                    {
+                      backgroundColor: settings.fontFamily === option.value ? colors.accentMuted : colors.bgTertiary,
+                      borderColor: settings.fontFamily === option.value ? colors.accent : colors.border,
+                    }
+                  ]}
+                  onPress={() => setFontFamily(option.value)}
+                >
+                  <Text style={[
+                    styles.optionText,
+                    {
+                      color: settings.fontFamily === option.value ? colors.accent : colors.textSecondary,
+                      fontWeight: settings.fontFamily === option.value ? '600' : '400',
+                    }
+                  ]}>
+                    {fontFamilyLabels[option.labelKey]}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Preview */}
+          <View style={[styles.preview, { backgroundColor: colors.bgTertiary, borderColor: colors.border }]}>
+            <Text style={[styles.previewLabel, { color: colors.textMuted }]}>
+              {t.fontSettings.preview}
+            </Text>
+            <Text style={[styles.previewText, { color: colors.textSecondary }]}>
+              {t.fontSettings.previewText}
+            </Text>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  panel: {
+    width: '100%',
+    maxWidth: 400,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+  },
+  closeButton: {
+    padding: spacing.xs,
+  },
+  section: {
+    padding: spacing.lg,
+  },
+  sectionTitle: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
+    marginBottom: spacing.sm,
+  },
+  optionGroup: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  option: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    alignItems: 'center',
+  },
+  optionText: {
+    fontSize: fontSize.sm,
+  },
+  preview: {
+    margin: spacing.lg,
+    marginTop: 0,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+  },
+  previewLabel: {
+    fontSize: fontSize.xs,
+    marginBottom: spacing.xs,
+  },
+  previewText: {
+    fontSize: fontSize.base,
+    lineHeight: fontSize.base * 1.6,
+  },
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export { Card } from './Card';
 export { FAB } from './FAB';
 export { ThemeToggle } from './ThemeToggle';
 export { LanguageToggle } from './LanguageToggle';
+export { FontSettingsPanel } from './FontSettingsPanel';

--- a/src/contexts/FontSettingsContext.tsx
+++ b/src/contexts/FontSettingsContext.tsx
@@ -1,0 +1,117 @@
+/**
+ * Font Settings Context
+ * Manages font size and font family preferences
+ */
+
+import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { storage } from '../services/storage';
+
+export type FontSize = 'small' | 'medium' | 'large';
+export type FontFamily = 'system' | 'serif' | 'sans-serif';
+
+// Font size multipliers
+export const fontSizeMultipliers: Record<FontSize, number> = {
+  small: 0.85,
+  medium: 1.0,
+  large: 1.15,
+};
+
+// Font family stacks
+export const fontFamilyStacks: Record<FontFamily, string> = {
+  system: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  serif: 'Georgia, "Times New Roman", Times, serif',
+  'sans-serif': '"Helvetica Neue", Helvetica, Arial, sans-serif',
+};
+
+export interface FontSettings {
+  fontSize: FontSize;
+  fontFamily: FontFamily;
+}
+
+interface FontSettingsContextType {
+  settings: FontSettings;
+  setFontSize: (size: FontSize) => void;
+  setFontFamily: (family: FontFamily) => void;
+  getMultiplier: () => number;
+  getFontStack: () => string;
+}
+
+const STORAGE_KEY = 'md-viewer-font-settings';
+
+const defaultSettings: FontSettings = {
+  fontSize: 'medium',
+  fontFamily: 'system',
+};
+
+const FontSettingsContext = createContext<FontSettingsContextType | undefined>(undefined);
+
+export function FontSettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<FontSettings>(defaultSettings);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load settings from storage
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const saved = await storage.getItem(STORAGE_KEY);
+        if (saved) {
+          const parsed = JSON.parse(saved) as Partial<FontSettings>;
+          setSettings({
+            fontSize: parsed.fontSize || defaultSettings.fontSize,
+            fontFamily: parsed.fontFamily || defaultSettings.fontFamily,
+          });
+        }
+      } catch (error) {
+        console.error('Failed to load font settings:', error);
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+    loadSettings();
+  }, []);
+
+  // Save settings to storage
+  useEffect(() => {
+    if (isLoaded) {
+      storage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    }
+  }, [settings, isLoaded]);
+
+  const setFontSize = useCallback((size: FontSize) => {
+    setSettings(prev => ({ ...prev, fontSize: size }));
+  }, []);
+
+  const setFontFamily = useCallback((family: FontFamily) => {
+    setSettings(prev => ({ ...prev, fontFamily: family }));
+  }, []);
+
+  const getMultiplier = useCallback(() => {
+    return fontSizeMultipliers[settings.fontSize];
+  }, [settings.fontSize]);
+
+  const getFontStack = useCallback(() => {
+    return fontFamilyStacks[settings.fontFamily];
+  }, [settings.fontFamily]);
+
+  return (
+    <FontSettingsContext.Provider
+      value={{
+        settings,
+        setFontSize,
+        setFontFamily,
+        getMultiplier,
+        getFontStack,
+      }}
+    >
+      {children}
+    </FontSettingsContext.Provider>
+  );
+}
+
+export function useFontSettings(): FontSettingsContextType {
+  const context = useContext(FontSettingsContext);
+  if (!context) {
+    throw new Error('useFontSettings must be used within a FontSettingsProvider');
+  }
+  return context;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -14,3 +14,6 @@ export type { UseShareReturn } from './useShare';
 export { useTheme } from './useTheme';
 
 export { useLanguage } from './useLanguage';
+
+export { useFontSettings } from '../contexts/FontSettingsContext';
+export type { FontSize, FontFamily, FontSettings } from '../contexts/FontSettingsContext';

--- a/src/hooks/useShare.web.ts
+++ b/src/hooks/useShare.web.ts
@@ -4,7 +4,8 @@
  */
 
 import { useState, useCallback } from 'react';
-import { markdownToHtml } from '../utils/markdownToHtml';
+import { markdownToHtml, PdfFontSettings } from '../utils/markdownToHtml';
+import { useFontSettings, fontFamilyStacks, fontSizeMultipliers } from '../contexts/FontSettingsContext';
 
 export interface UseShareReturn {
   shareContent: (content: string, fileName: string) => Promise<void>;
@@ -16,6 +17,7 @@ export interface UseShareReturn {
 export function useShare(): UseShareReturn {
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { settings: fontSettings } = useFontSettings();
 
   // Generate PDF and return Blob URL
   const exportToPdf = useCallback(
@@ -26,10 +28,16 @@ export function useShare(): UseShareReturn {
       try {
         const html2pdf = (await import('html2pdf.js')).default;
 
-        const htmlContent = await markdownToHtml(content);
+        const pdfFontSettings: PdfFontSettings = {
+          fontSize: fontSettings.fontSize,
+          fontFamily: fontSettings.fontFamily,
+        };
+        const htmlContent = await markdownToHtml(content, pdfFontSettings);
+        const fontStack = fontFamilyStacks[fontSettings.fontFamily];
+        const baseFontSize = Math.round(11 * fontSizeMultipliers[fontSettings.fontSize]);
         const container = document.createElement('div');
         container.innerHTML = `
-          <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:11px;color:#1a1a1a;line-height:1.6;padding:16px;">
+          <div style="font-family:${fontStack};font-size:${baseFontSize}px;color:#1a1a1a;line-height:1.6;padding:16px;">
             ${htmlContent}
           </div>
         `;
@@ -61,7 +69,7 @@ export function useShare(): UseShareReturn {
         setIsProcessing(false);
       }
     },
-    []
+    [fontSettings]
   );
 
   // Generate and download PDF
@@ -73,10 +81,16 @@ export function useShare(): UseShareReturn {
       try {
         const html2pdf = (await import('html2pdf.js')).default;
 
-        const htmlContent = await markdownToHtml(content);
+        const pdfFontSettings: PdfFontSettings = {
+          fontSize: fontSettings.fontSize,
+          fontFamily: fontSettings.fontFamily,
+        };
+        const htmlContent = await markdownToHtml(content, pdfFontSettings);
+        const fontStack = fontFamilyStacks[fontSettings.fontFamily];
+        const baseFontSize = Math.round(11 * fontSizeMultipliers[fontSettings.fontSize]);
         const container = document.createElement('div');
         container.innerHTML = `
-          <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:11px;color:#1a1a1a;line-height:1.6;padding:16px;">
+          <div style="font-family:${fontStack};font-size:${baseFontSize}px;color:#1a1a1a;line-height:1.6;padding:16px;">
             ${htmlContent}
           </div>
         `;
@@ -115,7 +129,7 @@ export function useShare(): UseShareReturn {
         setIsProcessing(false);
       }
     },
-    []
+    [fontSettings]
   );
 
   return {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -125,6 +125,21 @@ export const en = {
     hoursAgo: '{hours}h ago',
     daysAgo: '{days}d ago',
   },
+
+  // Font Settings
+  fontSettings: {
+    title: 'Display Settings',
+    fontSize: 'Font Size',
+    fontFamily: 'Font Family',
+    small: 'Small',
+    medium: 'Medium',
+    large: 'Large',
+    system: 'System',
+    serif: 'Serif',
+    sansSerif: 'Sans-serif',
+    preview: 'Preview',
+    previewText: 'The quick brown fox jumps over the lazy dog.',
+  },
 };
 
 export type Translations = {
@@ -211,5 +226,18 @@ export type Translations = {
     minutesAgo: string;
     hoursAgo: string;
     daysAgo: string;
+  };
+  fontSettings: {
+    title: string;
+    fontSize: string;
+    fontFamily: string;
+    small: string;
+    medium: string;
+    large: string;
+    system: string;
+    serif: string;
+    sansSerif: string;
+    preview: string;
+    previewText: string;
   };
 };

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -127,4 +127,19 @@ export const ja: Translations = {
     hoursAgo: '{hours}時間前',
     daysAgo: '{days}日前',
   },
+
+  // Font Settings
+  fontSettings: {
+    title: '表示設定',
+    fontSize: 'フォントサイズ',
+    fontFamily: 'フォント',
+    small: '小',
+    medium: '中',
+    large: '大',
+    system: 'システム',
+    serif: '明朝体',
+    sansSerif: 'ゴシック体',
+    preview: 'プレビュー',
+    previewText: 'あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら。',
+  },
 };


### PR DESCRIPTION
## Summary
- Markdownプレビューのフォントサイズ・フォント種類を調整可能に
- 設定はPDF出力時にも反映される
- 設定はlocalStorageに保存され永続化

## Changes

### 新規ファイル
- `src/contexts/FontSettingsContext.tsx` - フォント設定Context
- `src/components/ui/FontSettingsPanel.tsx` - 設定UIパネル

### 変更ファイル
- `app/_layout.tsx` - FontSettingsProvider追加
- `app/viewer.tsx` - フォント設定ボタン・パネル追加
- `src/components/markdown/MarkdownRenderer.web.tsx` - フォント設定反映
- `src/utils/markdownToHtml.ts` - PDF出力用フォント設定対応
- `src/hooks/useShare.web.ts` - PDF出力時のフォント設定適用
- `src/i18n/locales/en.ts`, `ja.ts` - 翻訳文字列追加

## Features
- **フォントサイズ**: 小 (0.85x) / 中 (1.0x) / 大 (1.15x)
- **フォント**: システム / 明朝体 / ゴシック体
- 見出し・本文すべてに倍率を適用
- PDF出力時にも同じ設定を反映

## Test plan
- [ ] viewer画面でフォント設定ボタンが表示される
- [ ] 設定パネルでフォントサイズを変更できる
- [ ] 設定パネルでフォント種類を変更できる
- [ ] 変更がMarkdownプレビューにリアルタイムで反映される
- [ ] PDF出力時に設定が反映される
- [ ] ページリロード後も設定が維持される
- [ ] 日本語/英語の翻訳が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)