### PR TITLE
feat: Add settings menu to home screen header

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -126,6 +126,14 @@ export const en = {
     daysAgo: '{days}d ago',
   },
 
+  // Settings Menu
+  settings: {
+    theme: 'Theme',
+    light: 'Light',
+    dark: 'Dark',
+    language: 'Language',
+  },
+
   // Font Settings
   fontSettings: {
     title: 'Display Settings',
@@ -226,6 +234,12 @@ export type Translations = {
     minutesAgo: string;
     hoursAgo: string;
     daysAgo: string;
+  };
+  settings: {
+    theme: string;
+    light: string;
+    dark: string;
+    language: string;
   };
   fontSettings: {
     title: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -128,6 +128,14 @@ export const ja: Translations = {
     daysAgo: '{days}日前',
   },
 
+  // Settings Menu
+  settings: {
+    theme: 'テーマ',
+    light: 'ライト',
+    dark: 'ダーク',
+    language: '言語',
+  },
+
   // Font Settings
   fontSettings: {
     title: '表示設定',


### PR DESCRIPTION
## Summary
- トップページのヘッダーから常に表示されていたLanguageToggle/ThemeToggleを削除
- 代わりにメニューボタン（︙）を追加
- メニューからテーマ（ライト/ダーク）と言語（English/日本語）を切り替え可能

## Changes
- `app/index.tsx` - ヘッダーにメニューボタン追加、設定メニューUI実装
- `src/i18n/locales/en.ts`, `ja.ts` - 設定メニュー用の翻訳文字列追加

## UI
- メニューボタン: ヘッダー右側に配置（︙アイコン）
- 設定メニュー: ドロップダウン形式
  - テーマ選択: Light / Dark ボタン
  - 言語選択: English / 日本語 ボタン
  - About リンク

## Test plan
- [ ] メニューボタンをクリックすると設定メニューが表示される
- [ ] テーマを切り替えるとUIが即座に反映される
- [ ] 言語を切り替えると翻訳が即座に反映される
- [ ] メニュー外をクリックするとメニューが閉じる
- [ ] Aboutリンクをクリックするとaboutページに遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)