### PR TITLE
feat: Redesign UI with unified menu and simplified viewer header

### DIFF
--- a/app/search.tsx
+++ b/app/search.tsx
@@ -13,6 +13,7 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -44,6 +45,19 @@ export default function SearchScreen() {
       return () => clearTimeout(timer);
     }
   }, [isAuthenticated]);
+
+  // ESC key to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   const handleSearch = useCallback(
     (text: string) => {
@@ -150,6 +164,11 @@ export default function SearchScreen() {
               autoCorrect={false}
               returnKeyType="search"
               editable={isAuthenticated}
+              onKeyPress={(e) => {
+                if (e.nativeEvent.key === 'Escape') {
+                  handleClose();
+                }
+              }}
             />
             {isLoading && <ActivityIndicator size="small" color={colors.accent} />}
           </View>
@@ -158,8 +177,8 @@ export default function SearchScreen() {
           </TouchableOpacity>
         </View>
 
-        {/* Search Body */}
-        <View style={styles.body}>
+        {/* Search Body - tap outside to close */}
+        <Pressable style={styles.body} onPress={handleClose}>
           {!isAuthenticated ? (
             <View style={styles.authPrompt}>
               <Text style={[styles.authText, { color: colors.textSecondary }]}>
@@ -212,7 +231,7 @@ export default function SearchScreen() {
               }
             />
           )}
-        </View>
+        </Pressable>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );

--- a/src/contexts/FontSettingsContext.tsx
+++ b/src/contexts/FontSettingsContext.tsx
@@ -11,9 +11,9 @@ export type FontFamily = 'system' | 'serif' | 'sans-serif';
 
 // Font size multipliers
 export const fontSizeMultipliers: Record<FontSize, number> = {
-  small: 0.85,
+  small: 0.9,
   medium: 1.0,
-  large: 1.15,
+  large: 1.1,
 };
 
 // Font family stacks

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -148,6 +148,22 @@ export const en = {
     preview: 'Preview',
     previewText: 'The quick brown fox jumps over the lazy dog.',
   },
+
+  // Menu
+  menu: {
+    title: 'Menu',
+    account: 'Account',
+    display: 'Display Settings',
+  },
+
+  // File Info
+  fileInfo: {
+    title: 'File Info',
+    source: 'Source',
+    googleDrive: 'Google Drive',
+    local: 'Local File',
+    exportPdf: 'Export PDF',
+  },
 };
 
 export type Translations = {
@@ -253,5 +269,17 @@ export type Translations = {
     sansSerif: string;
     preview: string;
     previewText: string;
+  };
+  menu: {
+    title: string;
+    account: string;
+    display: string;
+  };
+  fileInfo: {
+    title: string;
+    source: string;
+    googleDrive: string;
+    local: string;
+    exportPdf: string;
   };
 };

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -150,4 +150,20 @@ export const ja: Translations = {
     preview: 'プレビュー',
     previewText: 'あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら。',
   },
+
+  // Menu
+  menu: {
+    title: 'メニュー',
+    account: 'アカウント',
+    display: '表示設定',
+  },
+
+  // File Info
+  fileInfo: {
+    title: 'ファイル情報',
+    source: 'ソース',
+    googleDrive: 'Google Drive',
+    local: 'ローカルファイル',
+    exportPdf: 'PDF出力',
+  },
 };

--- a/src/theme/spacing.ts
+++ b/src/theme/spacing.ts
@@ -25,14 +25,14 @@ export const borderRadius = {
 export type BorderRadiusKey = keyof typeof borderRadius;
 
 export const fontSize = {
-  xs: 12,
-  sm: 14,
-  base: 16,
-  lg: 18,
-  xl: 20,
-  '2xl': 24,
-  '3xl': 30,
-  '4xl': 36,
+  xs: 11,
+  sm: 13,
+  base: 15,
+  lg: 17,
+  xl: 19,
+  '2xl': 22,
+  '3xl': 28,
+  '4xl': 34,
 } as const;
 
 export type FontSizeKey = keyof typeof fontSize;


### PR DESCRIPTION
## Summary

- **Home screen (unauthenticated)**: Header hidden, landing page with login/local file buttons in first view
- **Home screen (authenticated)**: New header layout with hamburger menu (left) + search bar (center)
- **Unified slide-in menu**: Combines settings and user menu into single left slide-in panel
  - Account info (name, email)
  - Display settings (font size, font family)
  - Theme toggle (Light/Dark)
  - Language toggle (EN/JA)
  - Open local file
  - About
  - Sign out
- **Viewer screen**: Simplified header with back button (<) + tappable filename (center)
- **File info dialog**: Tapping filename shows dialog with file info, display settings, theme, and PDF export
- **Keyboard shortcuts**: Cmd+K / Ctrl+K to open search, ESC to close search
- **Search improvements**: Tap outside search bar to close, ESC works while typing
- **Font size adjustment**: Base font sizes reduced across the app

## Test plan

- [ ] Unauthenticated: Header is hidden
- [ ] Unauthenticated: Login and local file buttons visible in first view
- [ ] Authenticated: Header shows hamburger menu on left
- [ ] Authenticated: Header shows search bar in center
- [ ] Menu opens from left with slide animation
- [ ] All menu functions work (font, theme, language, local file, about, sign out)
- [ ] Viewer: Tapping filename opens dialog
- [ ] Viewer: PDF export works from dialog
- [ ] Cmd+K opens search
- [ ] ESC closes search (including while typing)
- [ ] Tap outside search bar closes search
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)