### PR TITLE
feat: Add privacy notice to landing page and search screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -206,7 +206,7 @@ export default function HomeScreen() {
         {/* Landing Page for Non-authenticated Users */}
         {!isAuthenticated ? (
           <View style={styles.landingContainer}>
-            {/* Hero Section */}
+            {/* Hero Section with CTA */}
             <View style={styles.heroSection}>
               <Image
                 source={require('../assets/images/icon.png')}
@@ -217,6 +217,30 @@ export default function HomeScreen() {
               <Text style={[styles.heroSubtitle, { color: colors.textSecondary }]}>
                 {t.home.subtitle}
               </Text>
+
+              {/* Primary CTA */}
+              <Button
+                onPress={authenticate}
+                disabled={!isApiLoaded}
+                loading={isLoading}
+                style={styles.heroCta}
+                icon={<Ionicons name="logo-google" size={20} color={colors.bgPrimary} />}
+              >
+                {t.home.signIn}
+              </Button>
+
+              {/* Privacy Notice */}
+              <View style={[styles.privacyNotice, { backgroundColor: colors.accentMuted, borderColor: colors.accent }]}>
+                <Ionicons name="shield-checkmark-outline" size={20} color={colors.accent} />
+                <View style={styles.privacyContent}>
+                  <Text style={[styles.privacyTitle, { color: colors.accent }]}>
+                    {t.search.privacyTitle}
+                  </Text>
+                  <Text style={[styles.privacyDesc, { color: colors.textSecondary }]}>
+                    {t.search.privacyDesc}
+                  </Text>
+                </View>
+              </View>
             </View>
 
             {/* Features Section */}
@@ -258,18 +282,8 @@ export default function HomeScreen() {
               </View>
             </View>
 
-            {/* CTA Section */}
-            <View style={styles.ctaSection}>
-              <Button
-                onPress={authenticate}
-                disabled={!isApiLoaded}
-                loading={isLoading}
-                style={styles.ctaButton}
-                icon={<Ionicons name="logo-google" size={20} color={colors.bgPrimary} />}
-              >
-                {t.home.signIn}
-              </Button>
-
+            {/* Secondary CTA */}
+            <View style={styles.secondaryCta}>
               <View style={styles.divider}>
                 <View style={[styles.dividerLine, { backgroundColor: colors.border }]} />
                 <Text style={[styles.dividerText, { color: colors.textMuted }]}>{t.home.or}</Text>
@@ -333,10 +347,23 @@ export default function HomeScreen() {
 
             {recentFiles.length === 0 && (
               <View style={styles.emptyState}>
-                <Ionicons name="document-text-outline" size={48} color={colors.textMuted} />
+                <Ionicons name="search-outline" size={48} color={colors.textMuted} />
                 <Text style={[styles.emptyStateText, { color: colors.textMuted }]}>
                   {t.home.searchPlaceholder}
                 </Text>
+
+                {/* Privacy Notice */}
+                <View style={[styles.privacyNotice, { backgroundColor: colors.accentMuted, borderColor: colors.accent }]}>
+                  <Ionicons name="shield-checkmark-outline" size={20} color={colors.accent} />
+                  <View style={styles.privacyContent}>
+                    <Text style={[styles.privacyTitle, { color: colors.accent }]}>
+                      {t.search.privacyTitle}
+                    </Text>
+                    <Text style={[styles.privacyDesc, { color: colors.textSecondary }]}>
+                      {t.search.privacyDesc}
+                    </Text>
+                  </View>
+                </View>
               </View>
             )}
           </View>
@@ -663,20 +690,22 @@ const styles = StyleSheet.create({
     lineHeight: fontSize.sm * 1.5,
   },
 
-  // CTA
-  ctaSection: {
-    marginTop: spacing['2xl'],
-    alignItems: 'center',
+  // Hero CTA
+  heroCta: {
+    marginTop: spacing.xl,
   },
-  ctaButton: {
-    marginBottom: spacing.md,
+
+  // Secondary CTA
+  secondaryCta: {
+    marginTop: spacing.xl,
+    alignItems: 'center',
   },
   divider: {
     flexDirection: 'row',
     alignItems: 'center',
     width: '100%',
     maxWidth: 280,
-    marginVertical: spacing.md,
+    marginBottom: spacing.md,
   },
   dividerLine: {
     flex: 1,
@@ -697,6 +726,30 @@ const styles = StyleSheet.create({
   },
   learnMoreText: {
     fontSize: fontSize.sm,
+  },
+
+  // Privacy Notice
+  privacyNotice: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+    marginTop: spacing.xl,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    maxWidth: 320,
+  },
+  privacyContent: {
+    flex: 1,
+  },
+  privacyTitle: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.semibold,
+    marginBottom: spacing.xs,
+  },
+  privacyDesc: {
+    fontSize: fontSize.xs,
+    lineHeight: fontSize.xs * 1.5,
   },
 
   // Authenticated Content

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -198,6 +198,19 @@ export default function SearchScreen() {
               <Text style={[styles.emptyHint, { color: colors.textMuted }]}>
                 {t.search.emptyHint}
               </Text>
+
+              {/* Privacy Notice */}
+              <View style={[styles.privacyNotice, { backgroundColor: colors.accentMuted, borderColor: colors.accent }]}>
+                <Ionicons name="shield-checkmark-outline" size={20} color={colors.accent} />
+                <View style={styles.privacyContent}>
+                  <Text style={[styles.privacyTitle, { color: colors.accent }]}>
+                    {t.search.privacyTitle}
+                  </Text>
+                  <Text style={[styles.privacyDesc, { color: colors.textSecondary }]}>
+                    {t.search.privacyDesc}
+                  </Text>
+                </View>
+              </View>
             </View>
           ) : query.length < 2 ? (
             <View style={styles.messageContainer}>
@@ -320,6 +333,30 @@ const styles = StyleSheet.create({
   },
   emptyHint: {
     fontSize: fontSize.sm,
+  },
+
+  // Privacy Notice
+  privacyNotice: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+    marginTop: spacing['2xl'],
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    maxWidth: 320,
+  },
+  privacyContent: {
+    flex: 1,
+  },
+  privacyTitle: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.semibold,
+    marginBottom: spacing.xs,
+  },
+  privacyDesc: {
+    fontSize: fontSize.xs,
+    lineHeight: fontSize.xs * 1.5,
   },
 
   // Message

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -54,6 +54,8 @@ export const en = {
     noResultsHint: 'Try searching with different keywords',
     resultCount: '{count} result',
     resultsCount: '{count} results',
+    privacyTitle: 'Your Privacy Matters',
+    privacyDesc: 'Files are fetched directly from Google Drive and rendered in your browser. Nothing is stored on our servers.',
   },
 
   // About Screen
@@ -204,6 +206,8 @@ export type Translations = {
     noResultsHint: string;
     resultCount: string;
     resultsCount: string;
+    privacyTitle: string;
+    privacyDesc: string;
   };
   about: {
     title: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -56,6 +56,8 @@ export const ja: Translations = {
     noResultsHint: '別のキーワードで検索してみてください',
     resultCount: '{count}件',
     resultsCount: '{count}件',
+    privacyTitle: 'プライバシーを守ります',
+    privacyDesc: 'ファイルはGoogle Driveから直接取得し、ブラウザ内で表示します。サーバーには一切保存されません。',
   },
 
   // About Screen


### PR DESCRIPTION
## Summary

- Redesign landing page layout with login button and privacy notice in hero section (KV/splash style)
- Add privacy notice component showing "Files are fetched directly from Google Drive and rendered in your browser. Nothing is stored on our servers."
- Display privacy notice in three locations:
  - Landing page (unauthenticated) - below login button in hero section
  - Home screen (authenticated, no history) - below search placeholder
  - Search screen (empty state) - below search hint

## Test plan

- [ ] Landing page: Privacy notice appears below login button
- [ ] Landing page: Features section appears after hero
- [ ] Landing page: Local file button appears at bottom
- [ ] Authenticated (no history): Privacy notice appears
- [ ] Search screen (empty): Privacy notice appears
- [ ] Translations work for EN/JA
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)