### PR TITLE
chore: Deploy only on main branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "buildCommand": "npx expo export -p web",
   "outputDirectory": "dist",
   "framework": null,
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

- Add `ignoreCommand` to vercel.json to skip builds for non-main branches
- Only `main` branch pushes will trigger Vercel deployments

## Changes

```json
"ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)