### PR TITLE
fix: Fix slide-in menu issues on mobile Safari

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -380,6 +380,7 @@ export default function HomeScreen() {
 
       {/* Slide-in Menu */}
       <Animated.View
+        pointerEvents={isMenuOpen ? 'auto' : 'none'}
         style={[
           styles.slideMenu,
           {
@@ -396,8 +397,12 @@ export default function HomeScreen() {
                 <Ionicons name="person" size={28} color={colors.textMuted} />
               </View>
               <View style={styles.menuUserInfo}>
-                <Text style={[styles.menuUserName, { color: colors.textPrimary }]}>{userInfo.displayName}</Text>
-                <Text style={[styles.menuUserEmail, { color: colors.textMuted }]}>{userInfo.email}</Text>
+                <Text style={[styles.menuUserName, { color: colors.textPrimary }]} numberOfLines={1}>
+                  {userInfo.displayName}
+                </Text>
+                <Text style={[styles.menuUserEmail, { color: colors.textMuted }]} numberOfLines={1}>
+                  {userInfo.email}
+                </Text>
               </View>
             </View>
           )}
@@ -855,6 +860,7 @@ const styles = StyleSheet.create({
   },
   menuUserInfo: {
     flex: 1,
+    overflow: 'hidden',
   },
   menuUserName: {
     fontSize: fontSize.base,


### PR DESCRIPTION
## Summary

Fix issues with the slide-in menu on mobile Safari:
- Menu couldn't be opened properly
- Account email displayed incorrectly (text overflow)

## Changes

- Add `pointerEvents={isMenuOpen ? 'auto' : 'none'}` to Animated.View to prevent touch events when menu is closed
- Add `numberOfLines={1}` to user name and email Text components
- Add `overflow: 'hidden'` to menuUserInfo style

## Test plan

- [ ] iPhone Safari: Menu opens correctly
- [ ] iPhone Safari: Email displays properly (truncated if too long)
- [ ] Desktop: Menu still works as expected
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)