### PR TITLE
feat: Add fullscreen mode to viewer

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -40,6 +40,8 @@ export const en = {
     authRequired: 'Authentication required. Please go back to home and sign in.',
     loadFailed: 'Failed to load file',
     errorOccurred: 'An error occurred',
+    fullscreen: 'Fullscreen',
+    exitFullscreen: 'Exit Fullscreen',
   },
 
   // Search Screen
@@ -194,6 +196,8 @@ export type Translations = {
     authRequired: string;
     loadFailed: string;
     errorOccurred: string;
+    fullscreen: string;
+    exitFullscreen: string;
   };
   search: {
     placeholder: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -42,6 +42,8 @@ export const ja: Translations = {
     authRequired: '認証が必要です。ホームに戻ってサインインしてください。',
     loadFailed: 'ファイルの読み込みに失敗しました',
     errorOccurred: 'エラーが発生しました',
+    fullscreen: '全画面',
+    exitFullscreen: '全画面を終了',
   },
 
   // Search Screen


### PR DESCRIPTION
## Summary

- ビューア画面に全画面モードを追加
- ヘッダー右側に全画面トグルボタンを配置
- 全画面時はヘッダーを自動非表示（タップで表示/非表示切替）
- Fullscreen API 対応（Android Chrome / デスクトップ）
- キーボードショートカット `F` キーで全画面切替

### プラットフォーム別の挙動

| プラットフォーム | 挙動 |
|-----------------|------|
| iOS Safari | ヘッダー非表示のみ（Fullscreen API 未対応のため） |
| Android Chrome | ヘッダー非表示 + ブラウザUI非表示 |
| デスクトップ | ヘッダー非表示 + ブラウザUI非表示 + `F`キー対応 |

## Test plan

- [ ] ヘッダーの全画面ボタンをタップして全画面モードに入れる
- [ ] 全画面モードでコンテンツをタップするとヘッダーが表示される
- [ ] ヘッダー表示後3秒で自動的に非表示になる
- [ ] 全画面モードで閉じるボタン（×）をタップすると通常モードに戻る
- [ ] デスクトップで `F` キーを押すと全画面モードが切り替わる
- [ ] ESC キーで全画面モードが終了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)