### PR TITLE
style: Increase markdown preview horizontal padding

### DIFF
--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -594,7 +594,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    paddingHorizontal: spacing.sm,
+    paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
   },
   fullscreenContent: {


### PR DESCRIPTION
## Summary
- Markdownプレビューの左右の余白を8px (spacing.sm) から16px (spacing.md) に増加

## Test plan
- [ ] 開発サーバーでMarkdownファイルを表示し、左右の余白が16pxになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)