### PR TITLE
fix: Fix slide menu overlay and show user profile image

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -392,23 +392,30 @@ export default function HomeScreen() {
       )}
 
       {/* Slide-in Menu */}
-      <Animated.View
-        pointerEvents={isMenuOpen ? 'auto' : 'none'}
-        style={[
-          styles.slideMenu,
-          {
-            backgroundColor: colors.bgSecondary,
-            transform: [{ translateX: menuAnimation }],
-          },
-        ]}
-      >
+      {isMenuOpen && (
+        <Animated.View
+          style={[
+            styles.slideMenu,
+            {
+              backgroundColor: colors.bgSecondary,
+              transform: [{ translateX: menuAnimation }],
+            },
+          ]}
+        >
         <SafeAreaView style={styles.slideMenuContent} edges={['top']}>
           {/* User Info */}
           {userInfo && (
             <View style={[styles.menuUserSection, { borderBottomColor: colors.border }]}>
-              <View style={[styles.menuAvatar, { backgroundColor: colors.bgTertiary }]}>
-                <Ionicons name="person" size={28} color={colors.textMuted} />
-              </View>
+              {userInfo.photoUrl ? (
+                <Image
+                  source={{ uri: userInfo.photoUrl }}
+                  style={styles.menuAvatarImage}
+                />
+              ) : (
+                <View style={[styles.menuAvatar, { backgroundColor: colors.bgTertiary }]}>
+                  <Ionicons name="person" size={28} color={colors.textMuted} />
+                </View>
+              )}
               <View style={styles.menuUserInfo}>
                 <Text style={[styles.menuUserName, { color: colors.textPrimary }]} numberOfLines={1}>
                   {userInfo.displayName}
@@ -584,6 +591,7 @@ export default function HomeScreen() {
           </ScrollView>
         </SafeAreaView>
       </Animated.View>
+      )}
 
       {/* Search FAB */}
       {isAuthenticated && (
@@ -888,6 +896,11 @@ const styles = StyleSheet.create({
     borderRadius: 24,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  menuAvatarImage: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
   },
   menuUserInfo: {
     flex: 1,


### PR DESCRIPTION
## Summary
- スライドインメニューが閉じている状態でもユーザーアバターがメニューボタンに重なって表示される問題を修正
- Googleログイン後、メニュー内のユーザーセクションにプロフィール画像を表示するよう改善

## Changes
- `isMenuOpen && (...)` による条件付きレンダリングでメニューを完全に非表示に
- `userInfo.photoUrl` が存在する場合にプロフィール画像を表示、ない場合はデフォルトアイコンを使用
- `menuAvatarImage` スタイルを追加

## Test plan
- [ ] ログイン後、メニューボタンにユーザーアイコンが重なっていないことを確認
- [ ] メニューを開いて、Googleプロフィール画像が表示されることを確認
- [ ] プロフィール画像がない場合、デフォルトのアイコンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)