### PR TITLE
fix: PWAスタンドアロンモードのスペース・ヘッダー問題を修正

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -10,11 +10,11 @@ export default function Root({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
         {/* Apple PWA meta tags */}
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="MD Viewer" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 


### PR DESCRIPTION
## Summary
- `viewport-fit=cover` を削除し、スタンドアロンモードでの余計な下部スペースを解消
- `apple-mobile-web-app-status-bar-style` を `default` に変更し、全画面ヘッダーの閉じるボタンがステータスバーに隠れてタップできない問題を修正

## Changes
- `app/+html.tsx` - viewport meta と status-bar-style meta の修正（2行）

## Test plan
- [ ] PWAスタンドアロンモードで下部に余計なスペースがないこと
- [ ] Viewer全画面モードで閉じるボタンがタップ可能なこと
- [ ] 通常のSafariブラウザで表示崩れがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)