### PR TITLE
feat: Add Google Analytics tracking

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -26,7 +26,9 @@ export default function Root({ children }: { children: React.ReactNode }) {
 
         {/* Using raw CSS styles as an escape-hatch to ensure the background color never flickers in dark-mode. */}
         <style dangerouslySetInnerHTML={{ __html: responsiveBackground }} />
-        {/* Add any additional <head> elements that you want globally available on web... */}
+        {/* Google Analytics */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKEK6L4D33" />
+        <script dangerouslySetInnerHTML={{ __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-YKEK6L4D33');` }} />
       </head>
       <body>{children}</body>
     </html>

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -36,9 +36,9 @@ MD Viewer は**完全にクライアントサイドで動作**します。
 
 ### サーバーに送信されるデータ
 
-**なし**
+MD Viewer のホスティングサーバー（Vercel）にはアプリケーションコードのみが配置されており、ユーザーデータは送信されません。
 
-MD Viewer のホスティングサーバー（Vercel）にはアプリケーションコードのみが配置されています。ユーザーデータは一切送信されません。
+ただし、アクセス解析のために Google Analytics へ匿名の利用データ（ページビュー、デバイス情報等）が送信されます。詳細は「サードパーティサービス > アクセス解析」を参照してください。
 
 ### Google に送信されるデータ
 
@@ -142,6 +142,25 @@ MD Viewer は Google の以下のサービスを使用します:
 |---------|------|---------------------|
 | Google Identity Services | OAuth 認証 | [Google プライバシーポリシー](https://policies.google.com/privacy) |
 | Google Drive API | ファイル検索・取得 | [Google Drive 利用規約](https://www.google.com/drive/terms-of-service/) |
+
+### アクセス解析
+
+| サービス | 用途 | プライバシーポリシー |
+|---------|------|---------------------|
+| Google Analytics | アクセス解析（ページビュー等） | [Google プライバシーポリシー](https://policies.google.com/privacy) |
+
+MD Viewer はサービス改善のために Google Analytics を使用し、以下の匿名データを収集します:
+
+- ページビュー
+- おおよその地域情報
+- デバイス・ブラウザの種類
+
+**収集しないデータ:**
+- ファイル内容
+- Google Drive のファイル名・ファイル ID
+- 個人を特定できる情報
+
+> Google Analytics はブラウザの Cookie を使用します。Cookie の使用を望まない場合は、ブラウザの設定で無効にするか、[Google Analytics オプトアウトアドオン](https://tools.google.com/dlpage/gaoptout)をご利用ください。
 
 ### ホスティング
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -115,7 +115,7 @@ export const en = {
     },
     privacy: 'Privacy & Security',
     privacyDesc:
-      'MD Viewer only requests read-only access to your Google Drive files. Your documents are never stored on our servers - they are fetched directly from Google Drive and rendered in your browser. Your authentication tokens are stored securely in your browser\'s local storage.',
+      'MD Viewer only requests read-only access to your Google Drive files. Your documents are never stored on our servers - they are fetched directly from Google Drive and rendered in your browser. We use Google Analytics to collect anonymous usage data for service improvement.',
     license: 'License',
     licenseDesc: 'MD Viewer is open source software released under the MIT License.',
     viewLicense: 'View License',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -117,7 +117,7 @@ export const ja: Translations = {
     },
     privacy: 'プライバシーとセキュリティ',
     privacyDesc:
-      'MD ViewerはGoogle Driveファイルへの読み取り専用アクセスのみを要求します。ドキュメントは当社のサーバーに保存されることはなく、Google Driveから直接取得してブラウザでレンダリングされます。認証トークンはブラウザのローカルストレージに安全に保存されます。',
+      'MD ViewerはGoogle Driveファイルへの読み取り専用アクセスのみを要求します。ドキュメントは当社のサーバーに保存されることはなく、Google Driveから直接取得してブラウザでレンダリングされます。サービス改善のためGoogle Analyticsによる匿名のアクセス解析を行っています。',
     license: 'ライセンス',
     licenseDesc: 'MD ViewerはMITライセンスの下で公開されているオープンソースソフトウェアです。',
     viewLicense: 'ライセンスを見る',


### PR DESCRIPTION
## Summary
- Google Analytics (G-YKEK6L4D33) を `app/+html.tsx` に導入
- プライバシーポリシー (`docs/privacy.md`) に Google Analytics のデータ収集・オプトアウト方法を追記
- i18n の about 画面プライバシー説明文を日英とも更新

## Test plan
- [ ] 開発サーバーでページを開き、ブラウザのネットワークタブで `gtag` リクエストが送信されることを確認
- [ ] Google Analytics リアルタイムレポートでアクセスが記録されることを確認
- [ ] about 画面のプライバシー説明文が更新されていることを確認（日本語・英語）

🤖 Generated with [Claude Code](https://claude.com/claude-code)