### PR TITLE
fix: Update privacy policy pages to reflect Google Analytics integration

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -232,7 +232,7 @@ export const en = {
         },
         notCollect: {
           title: '3. Information We Do Not Collect',
-          body: 'We do not collect, store, or transmit:\n\n• Contents of your Markdown files\n• Personal information or profile data\n• Analytics or usage tracking data\n• Cookies for tracking purposes\n• Any data to external servers',
+          body: 'We do not collect, store, or transmit:\n\n• Contents of your Markdown files\n• Personal information or profile data\n• Google Drive file names or file IDs\n\nHowever, we use Google Analytics to collect anonymous usage data such as page views, approximate geographic location, and device/browser type for service improvement.',
         },
         google: {
           title: '4. Google API Usage',
@@ -240,11 +240,11 @@ export const en = {
         },
         storage: {
           title: '5. Data Storage',
-          body: 'All data is stored exclusively in your browser\'s localStorage. No data is transmitted to or stored on external servers. You can clear all stored data at any time by clearing your browser\'s local storage or signing out of the Service.',
+          body: 'User preferences and settings are stored exclusively in your browser\'s localStorage. You can clear all stored data at any time by clearing your browser\'s local storage or signing out of the Service. Google Analytics uses cookies for usage analysis. You can delete or disable cookies through your browser settings.',
         },
         thirdParty: {
           title: '6. Third-Party Services',
-          body: 'The Service integrates with Google Drive API for file access. When you sign in with Google, your authentication is handled directly by Google\'s Identity Services. We recommend reviewing Google\'s Privacy Policy for information about how Google handles your data.',
+          body: 'The Service integrates with Google Drive API for file access. When you sign in with Google, your authentication is handled directly by Google\'s Identity Services. We also use Google Analytics to collect anonymous usage data for service improvement. To opt out of Google Analytics, you can use the Google Analytics Opt-out Browser Add-on. We recommend reviewing Google\'s Privacy Policy for information about how Google handles your data.',
         },
         children: {
           title: '7. Children\'s Privacy',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -234,7 +234,7 @@ export const ja: Translations = {
         },
         notCollect: {
           title: '3. 収集しない情報',
-          body: '以下の情報は収集、保存、送信しません。\n\n• Markdownファイルの内容\n• 個人情報やプロフィールデータ\n• アナリティクスや使用状況のトラッキングデータ\n• トラッキング目的のCookie\n• 外部サーバーへのいかなるデータ',
+          body: '以下の情報は収集、保存、送信しません。\n\n• Markdownファイルの内容\n• 個人情報やプロフィールデータ\n• Google Driveのファイル名やファイルID\n\nなお、サービス改善のためGoogle Analyticsを使用し、ページビュー、おおよその地域情報、デバイス・ブラウザの種類などの匿名データを収集しています。',
         },
         google: {
           title: '4. Google APIの利用',
@@ -242,11 +242,11 @@ export const ja: Translations = {
         },
         storage: {
           title: '5. データの保存',
-          body: 'すべてのデータはブラウザのlocalStorageにのみ保存されます。データが外部サーバーに送信または保存されることはありません。ブラウザのローカルストレージをクリアするか、本サービスからサインアウトすることで、いつでも保存されたすべてのデータを削除できます。',
+          body: 'ユーザー設定等のデータはブラウザのlocalStorageにのみ保存されます。ブラウザのローカルストレージをクリアするか、本サービスからサインアウトすることで、いつでも保存されたデータを削除できます。なお、Google Analyticsはアクセス解析のためにCookieを使用します。Cookieはブラウザの設定から削除・無効化できます。',
         },
         thirdParty: {
           title: '6. サードパーティサービス',
-          body: '本サービスはファイルアクセスのためにGoogle Drive APIと連携しています。Googleでサインインすると、認証はGoogleのIdentity Servicesによって直接処理されます。Googleがお客様のデータをどのように取り扱うかについては、Googleのプライバシーポリシーをご確認ください。',
+          body: '本サービスはファイルアクセスのためにGoogle Drive APIと連携しています。Googleでサインインすると、認証はGoogleのIdentity Servicesによって直接処理されます。また、サービス改善のためGoogle Analyticsを使用しており、匿名のアクセスデータがGoogleに送信されます。Google Analyticsのオプトアウトをご希望の場合は、Google Analytics オプトアウトアドオンをご利用ください。Googleがお客様のデータをどのように取り扱うかについては、Googleのプライバシーポリシーをご確認ください。',
         },
         children: {
           title: '7. お子様のプライバシー',


### PR DESCRIPTION
## Summary
- `privacy.tsx` で表示される legal.privacy セクションを Google Analytics 導入に合わせて更新
- 「収集しない情報」から「アナリティクスやトラッキングデータ」「トラッキング目的のCookie」を削除し、GA による匿名データ収集を明記
- 「サードパーティサービス」に Google Analytics の使用とオプトアウト方法を追記
- 「データの保存」に Google Analytics の Cookie 使用について追記
- 日本語・英語ともに更新

## Test plan
- [ ] `/privacy` ページで「収集しない情報」セクションに GA の記載があることを確認
- [ ] 「サードパーティサービス」に GA とオプトアウトの記載があることを確認
- [ ] 「データの保存」に Cookie の記載があることを確認
- [ ] 日本語・英語の両方で表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)