### PR TITLE
feat: Add privacy policy and terms links to home page

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -318,6 +318,17 @@ export default function HomeScreen() {
               <Text style={[styles.learnMoreText, { color: colors.accent }]}>{t.home.learnMore}</Text>
               <Ionicons name="arrow-forward" size={16} color={colors.accent} />
             </TouchableOpacity>
+
+            {/* Footer Legal Links */}
+            <View style={styles.footerLegal}>
+              <TouchableOpacity onPress={() => router.push('/privacy')}>
+                <Text style={[styles.footerLegalText, { color: colors.textMuted }]}>{t.about.viewPrivacy}</Text>
+              </TouchableOpacity>
+              <Text style={[styles.footerLegalSeparator, { color: colors.textMuted }]}>|</Text>
+              <TouchableOpacity onPress={() => router.push('/terms')}>
+                <Text style={[styles.footerLegalText, { color: colors.textMuted }]}>{t.about.viewTerms}</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         ) : (
           <View style={styles.authenticatedContent}>
@@ -774,6 +785,19 @@ const styles = StyleSheet.create({
   },
   learnMoreText: {
     fontSize: fontSize.sm,
+  },
+  footerLegal: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: spacing.xl,
+    gap: spacing.sm,
+  },
+  footerLegalText: {
+    fontSize: fontSize.xs,
+  },
+  footerLegalSeparator: {
+    fontSize: fontSize.xs,
   },
 
   // Privacy Notice


### PR DESCRIPTION
## Summary
- ホームページ（ランディングページ）のフッターに「Privacy Policy | Terms of Service」リンクを追加
- `/privacy` と `/terms` ページへ遷移
- Google OAuth 審査で「ホームページにプライバシーポリシーへのリンクがない」と指摘された問題に対応

## Test plan
- [ ] 未認証状態でホームページにアクセスし、フッターに「Privacy Policy」と「Terms of Service」のリンクが表示されることを確認
- [ ] 各リンクをクリックして `/privacy` と `/terms` ページに遷移することを確認
- [ ] 日本語・英語の両方でリンクテキストが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)