### PR TITLE
fix: Use Link component for legal footer links for crawler accessibility

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,7 +16,7 @@ import {
   Dimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
+import { router, Link } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { spacing, borderRadius, fontSize, fontWeight, shadows } from '../src/theme';
 import { Button, LoadingSpinner, FAB } from '../src/components/ui';
@@ -321,13 +321,13 @@ export default function HomeScreen() {
 
             {/* Footer Legal Links */}
             <View style={styles.footerLegal}>
-              <TouchableOpacity onPress={() => router.push('/privacy')}>
-                <Text style={[styles.footerLegalText, { color: colors.textMuted }]}>{t.about.viewPrivacy}</Text>
-              </TouchableOpacity>
+              <Link href="/privacy" style={[styles.footerLegalText, { color: colors.textMuted }]}>
+                {t.about.viewPrivacy}
+              </Link>
               <Text style={[styles.footerLegalSeparator, { color: colors.textMuted }]}>|</Text>
-              <TouchableOpacity onPress={() => router.push('/terms')}>
-                <Text style={[styles.footerLegalText, { color: colors.textMuted }]}>{t.about.viewTerms}</Text>
-              </TouchableOpacity>
+              <Link href="/terms" style={[styles.footerLegalText, { color: colors.textMuted }]}>
+                {t.about.viewTerms}
+              </Link>
             </View>
           </View>
         ) : (


### PR DESCRIPTION
## Summary
- フッターのプライバシーポリシー・利用規約リンクを `TouchableOpacity` から expo-router の `Link` に変更
- Web で `<a>` タグとしてレンダリングされるようになり、クローラーがリンクを認識可能に
- Google OAuth 審査で「ホームページにプライバシーポリシーへのリンクがない」と指摘された問題への対応

## Test plan
- [ ] ホームページでリンクが `<a>` タグとしてレンダリングされていることを DevTools で確認
- [ ] リンクをクリックして `/privacy` と `/terms` に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)