### PR TITLE
fix: Add tappable GitHub Issues link to contact sections in legal pages

### DIFF
--- a/app/privacy.tsx
+++ b/app/privacy.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Linking,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -51,14 +52,26 @@ export default function PrivacyScreen() {
             {t.legal.privacy.lastUpdated}
           </Text>
 
-          {Object.values(sections).map((section, index) => (
-            <View key={index} style={styles.section}>
+          {Object.entries(sections).map(([key, section]) => (
+            <View key={key} style={styles.section}>
               <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
                 {section.title}
               </Text>
               <Text style={[styles.sectionBody, { color: colors.textSecondary }]}>
                 {section.body}
               </Text>
+              {'url' in section && section.url && (
+                <TouchableOpacity
+                  style={styles.contactLink}
+                  onPress={() => Linking.openURL(section.url)}
+                >
+                  <Ionicons name="logo-github" size={16} color={colors.accent} />
+                  <Text style={[styles.contactLinkText, { color: colors.accent }]}>
+                    GitHub Issues
+                  </Text>
+                  <Ionicons name="open-outline" size={14} color={colors.accent} />
+                </TouchableOpacity>
+              )}
             </View>
           ))}
         </View>
@@ -124,5 +137,15 @@ const styles = StyleSheet.create({
   sectionBody: {
     fontSize: fontSize.sm,
     lineHeight: fontSize.sm * 1.8,
+  },
+  contactLink: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.sm,
+  },
+  contactLinkText: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
   },
 });

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Linking,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -51,14 +52,26 @@ export default function TermsScreen() {
             {t.legal.terms.lastUpdated}
           </Text>
 
-          {Object.values(sections).map((section, index) => (
-            <View key={index} style={styles.section}>
+          {Object.entries(sections).map(([key, section]) => (
+            <View key={key} style={styles.section}>
               <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>
                 {section.title}
               </Text>
               <Text style={[styles.sectionBody, { color: colors.textSecondary }]}>
                 {section.body}
               </Text>
+              {'url' in section && section.url && (
+                <TouchableOpacity
+                  style={styles.contactLink}
+                  onPress={() => Linking.openURL(section.url)}
+                >
+                  <Ionicons name="logo-github" size={16} color={colors.accent} />
+                  <Text style={[styles.contactLinkText, { color: colors.accent }]}>
+                    GitHub Issues
+                  </Text>
+                  <Ionicons name="open-outline" size={14} color={colors.accent} />
+                </TouchableOpacity>
+              )}
             </View>
           ))}
         </View>
@@ -124,5 +137,15 @@ const styles = StyleSheet.create({
   sectionBody: {
     fontSize: fontSize.sm,
     lineHeight: fontSize.sm * 1.8,
+  },
+  contactLink: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.sm,
+  },
+  contactLinkText: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
   },
 });

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -215,6 +215,7 @@ export const en = {
         contact: {
           title: '7. Contact',
           body: 'For questions about these Terms of Service, please visit the project\'s GitHub repository.',
+          url: 'https://github.com/luckypool/md-viewer/issues',
         },
       },
     },
@@ -257,6 +258,7 @@ export const en = {
         contact: {
           title: '9. Contact',
           body: 'For questions about this Privacy Policy, please visit the project\'s GitHub repository.',
+          url: 'https://github.com/luckypool/md-viewer/issues',
         },
       },
     },
@@ -405,7 +407,7 @@ export type Translations = {
         intellectual: { title: string; body: string };
         disclaimer: { title: string; body: string };
         changes: { title: string; body: string };
-        contact: { title: string; body: string };
+        contact: { title: string; body: string; url: string };
       };
     };
     privacy: {
@@ -420,7 +422,7 @@ export type Translations = {
         thirdParty: { title: string; body: string };
         children: { title: string; body: string };
         changes: { title: string; body: string };
-        contact: { title: string; body: string };
+        contact: { title: string; body: string; url: string };
       };
     };
   };

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -217,6 +217,7 @@ export const ja: Translations = {
         contact: {
           title: '7. お問い合わせ',
           body: 'この利用規約に関するご質問は、プロジェクトのGitHubリポジトリをご覧ください。',
+          url: 'https://github.com/luckypool/md-viewer/issues',
         },
       },
     },
@@ -259,6 +260,7 @@ export const ja: Translations = {
         contact: {
           title: '9. お問い合わせ',
           body: 'このプライバシーポリシーに関するご質問は、プロジェクトのGitHubリポジトリをご覧ください。',
+          url: 'https://github.com/luckypool/md-viewer/issues',
         },
       },
     },


### PR DESCRIPTION
## Summary
- プライバシーポリシー・利用規約ページの「お問い合わせ」セクションに、GitHub Issues へのタップ可能なリンクを追加
- 翻訳データ (en.ts / ja.ts) の contact セクションに `url` フィールドを追加し、型定義も更新
- GitHub アイコン + 外部リンクアイコン付きで視覚的にわかりやすいリンクを表示

## Test plan
- [ ] プライバシーポリシーページを開き、お問い合わせセクションに GitHub Issues リンクが表示されることを確認
- [ ] 利用規約ページを開き、お問い合わせセクションに GitHub Issues リンクが表示されることを確認
- [ ] リンクをタップすると `https://github.com/luckypool/md-viewer/issues` が開くことを確認
- [ ] 日本語・英語の両方で正しく表示されることを確認
- [ ] `npx tsc --noEmit` で型エラーがないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)