### PR TITLE
Add robots.txt and sitemap.xml for SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,14 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+Allow: /about
+Allow: /privacy
+Allow: /terms
+Allow: /license
+Allow: /third-party-licenses
+
+# Disallow pages that require authentication
+Disallow: /viewer
+Disallow: /search
+
+Sitemap: https://my-md-viewer.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://my-md-viewer.vercel.app/</loc>
+    <priority>1.0</priority>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://my-md-viewer.vercel.app/about</loc>
+    <priority>0.8</priority>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://my-md-viewer.vercel.app/privacy</loc>
+    <priority>0.5</priority>
+    <changefreq>yearly</changefreq>
+  </url>
+  <url>
+    <loc>https://my-md-viewer.vercel.app/terms</loc>
+    <priority>0.5</priority>
+    <changefreq>yearly</changefreq>
+  </url>
+  <url>
+    <loc>https://my-md-viewer.vercel.app/license</loc>
+    <priority>0.4</priority>
+    <changefreq>yearly</changefreq>
+  </url>
+  <url>
+    <loc>https://my-md-viewer.vercel.app/third-party-licenses</loc>
+    <priority>0.4</priority>
+    <changefreq>monthly</changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
This PR adds SEO configuration files to improve search engine crawling and indexing of the application.

## Changes
- **robots.txt**: Added to guide search engine crawlers on which pages to index
  - Allows crawling of public pages: home, about, privacy, terms, license, and third-party-licenses
  - Disallows crawling of authenticated pages: viewer and search
  - References the sitemap for better discoverability
  
- **sitemap.xml**: Added XML sitemap listing all public pages with metadata
  - Includes priority levels (1.0 for homepage, 0.8 for about, 0.4-0.5 for legal pages)
  - Specifies change frequency for each page to help search engines determine crawl schedules
  - Covers all publicly accessible routes

## Implementation Details
- Both files are placed in the `public/` directory for proper serving
- The sitemap references the production domain (my-md-viewer.vercel.app)
- Authentication-required routes are properly excluded from indexing to prevent crawling errors

https://claude.ai/code/session_01MUeFPdHiWztw95ANcMNjkV