### PR TITLE
feat: Add edit mode with Google Drive write-back

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -17,3 +17,6 @@ export { useLanguage } from './useLanguage';
 
 export { useFontSettings } from '../contexts/FontSettingsContext';
 export type { FontSize, FontFamily, FontSettings } from '../contexts/FontSettingsContext';
+
+export { useMarkdownEditor } from './useMarkdownEditor';
+export type { UseMarkdownEditorReturn } from './useMarkdownEditor';

--- a/src/hooks/useGoogleAuth.web.ts
+++ b/src/hooks/useGoogleAuth.web.ts
@@ -19,7 +19,7 @@ const API_KEY = process.env.EXPO_PUBLIC_GOOGLE_API_KEY || '';
 const CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID || '';
 
 // Google API のスコープ
-const SCOPES = 'https://www.googleapis.com/auth/drive.readonly';
+const SCOPES = 'https://www.googleapis.com/auth/drive.file';
 
 // ストレージのキー
 const TOKEN_KEY = 'googleDriveAccessToken';
@@ -179,14 +179,19 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
         await loadScript('https://accounts.google.com/gsi/client');
 
         window.gapi.load('client:picker', async () => {
-          await window.gapi.client.init({
-            apiKey: API_KEY,
-            discoveryDocs: [
-              'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest',
-            ],
-          });
-          pickerInited.current = true;
-          checkApisLoaded();
+          try {
+            await window.gapi.client.init({
+              apiKey: API_KEY,
+              discoveryDocs: [
+                'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest',
+              ],
+            });
+            pickerInited.current = true;
+            checkApisLoaded();
+          } catch (initErr) {
+            console.error('gapi.client.init failed:', initErr);
+            setError('Failed to initialize Google API. Check API key referrer settings.');
+          }
         });
 
         tokenClientRef.current = window.google.accounts.oauth2.initTokenClient({

--- a/src/hooks/useMarkdownEditor.ts
+++ b/src/hooks/useMarkdownEditor.ts
@@ -1,0 +1,147 @@
+/**
+ * Markdown 編集状態管理フック
+ */
+
+import { useState, useCallback, useRef, useMemo } from 'react';
+import { updateFileContent } from '../services/googleDrive';
+
+interface UseMarkdownEditorOptions {
+  initialContent: string | null;
+  fileId: string;
+  source: 'google-drive' | 'local';
+  accessToken: string | null;
+  onContentSaved: (newContent: string) => void;
+}
+
+export interface UseMarkdownEditorReturn {
+  mode: 'preview' | 'edit';
+  editContent: string;
+  hasUnsavedChanges: boolean;
+  isSaving: boolean;
+  saveError: string | null;
+  saveSuccess: boolean;
+  needsReauth: boolean;
+  canEdit: boolean;
+  canSave: boolean;
+
+  toggleMode: () => void;
+  setEditContent: (content: string) => void;
+  save: () => Promise<boolean>;
+  discardChanges: () => void;
+}
+
+export function useMarkdownEditor({
+  initialContent,
+  fileId,
+  source,
+  accessToken,
+  onContentSaved,
+}: UseMarkdownEditorOptions): UseMarkdownEditorReturn {
+  const [mode, setMode] = useState<'preview' | 'edit'>('preview');
+  const [editContent, setEditContent] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [needsReauth, setNeedsReauth] = useState(false);
+
+  const baselineRef = useRef(initialContent || '');
+  const saveSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const canEdit = source === 'google-drive';
+  const hasUnsavedChanges = mode === 'edit' && editContent !== baselineRef.current;
+  const canSave = hasUnsavedChanges && !isSaving;
+
+  const toggleMode = useCallback(() => {
+    setMode((prev) => {
+      if (prev === 'preview') {
+        // preview → edit: baseline から editContent を初期化
+        setEditContent(baselineRef.current);
+        setSaveError(null);
+        setSaveSuccess(false);
+        setNeedsReauth(false);
+        return 'edit';
+      }
+      return 'preview';
+    });
+  }, []);
+
+  const save = useCallback(async (): Promise<boolean> => {
+    if (!accessToken || !canEdit) return false;
+
+    setIsSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    try {
+      await updateFileContent(accessToken, fileId, editContent);
+      baselineRef.current = editContent;
+      onContentSaved(editContent);
+      setSaveSuccess(true);
+
+      // 3秒後に成功メッセージをクリア
+      if (saveSuccessTimerRef.current) {
+        clearTimeout(saveSuccessTimerRef.current);
+      }
+      saveSuccessTimerRef.current = setTimeout(() => {
+        setSaveSuccess(false);
+      }, 3000);
+
+      return true;
+    } catch (err) {
+      if (err instanceof Error && err.message === 'INSUFFICIENT_SCOPE') {
+        setNeedsReauth(true);
+      }
+      setSaveError(err instanceof Error ? err.message : 'Failed to save');
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [accessToken, canEdit, editContent, fileId, onContentSaved]);
+
+  const discardChanges = useCallback(() => {
+    setEditContent(baselineRef.current);
+    setSaveError(null);
+    setSaveSuccess(false);
+    setNeedsReauth(false);
+    setMode('preview');
+  }, []);
+
+  // initialContent が変更されたら baseline を更新
+  const prevInitialContent = useRef(initialContent);
+  if (initialContent !== prevInitialContent.current) {
+    prevInitialContent.current = initialContent;
+    baselineRef.current = initialContent || '';
+  }
+
+  return useMemo(
+    () => ({
+      mode,
+      editContent,
+      hasUnsavedChanges,
+      isSaving,
+      saveError,
+      saveSuccess,
+      needsReauth,
+      canEdit,
+      canSave,
+      toggleMode,
+      setEditContent,
+      save,
+      discardChanges,
+    }),
+    [
+      mode,
+      editContent,
+      hasUnsavedChanges,
+      isSaving,
+      saveError,
+      saveSuccess,
+      needsReauth,
+      canEdit,
+      canSave,
+      toggleMode,
+      save,
+      discardChanges,
+    ]
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -42,6 +42,14 @@ export const en = {
     errorOccurred: 'An error occurred',
     fullscreen: 'Fullscreen',
     exitFullscreen: 'Exit Fullscreen',
+    edit: 'Edit',
+    preview: 'Preview',
+    saving: 'Saving...',
+    saved: 'Saved',
+    saveFailed: 'Failed to save',
+    unsavedChanges: 'You have unsaved changes. Discard them?',
+    save: 'Save',
+    reauthRequired: 'Please sign out and sign in again to enable editing',
   },
 
   // Search Screen
@@ -293,6 +301,14 @@ export type Translations = {
     errorOccurred: string;
     fullscreen: string;
     exitFullscreen: string;
+    edit: string;
+    preview: string;
+    saving: string;
+    saved: string;
+    saveFailed: string;
+    unsavedChanges: string;
+    save: string;
+    reauthRequired: string;
   };
   search: {
     placeholder: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -44,6 +44,14 @@ export const ja: Translations = {
     errorOccurred: 'エラーが発生しました',
     fullscreen: '全画面',
     exitFullscreen: '全画面を終了',
+    edit: '編集',
+    preview: 'プレビュー',
+    saving: '保存中...',
+    saved: '保存しました',
+    saveFailed: '保存に失敗しました',
+    unsavedChanges: '未保存の変更があります。破棄しますか？',
+    save: '保存',
+    reauthRequired: '編集を有効にするには、サインアウトして再度サインインしてください',
   },
 
   // Search Screen

--- a/src/services/googleDrive.ts
+++ b/src/services/googleDrive.ts
@@ -188,6 +188,35 @@ export async function listRecentMarkdownFiles(
   );
 }
 
+const DRIVE_UPLOAD_API_BASE = 'https://www.googleapis.com/upload/drive/v3';
+
+/**
+ * ファイル内容を更新（書き戻し）
+ */
+export async function updateFileContent(
+  accessToken: string,
+  fileId: string,
+  content: string,
+): Promise<void> {
+  const response = await fetch(
+    `${DRIVE_UPLOAD_API_BASE}/files/${fileId}?uploadType=media`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'text/markdown',
+      },
+      body: content,
+    }
+  );
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error('INSUFFICIENT_SCOPE');
+    }
+    throw new Error(`Failed to save: ${response.statusText}`);
+  }
+}
+
 /**
  * Markdown ファイルかどうかを判定
  */

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -14,4 +14,5 @@ export {
   searchMarkdownFiles,
   fetchFileContent,
   fetchFileInfo,
+  updateFileContent,
 } from './googleDrive';


### PR DESCRIPTION
## Summary

- Google Drive上のMarkdownファイルを直接編集・保存できる編集モードを追加
- 編集（TextInput）とプレビュー（既存MarkdownRenderer）をトグルで切り替えるUI
- OAuthスコープを`drive.readonly`→`drive.file`に変更し、ファイル書き込みを有効化
- `gapi.client.init`失敗時のエラーハンドリングを改善

### 変更内容

| ファイル | 概要 |
|---------|------|
| `src/hooks/useGoogleAuth.web.ts` | OAuthスコープ変更 + gapi初期化エラーハンドリング |
| `src/services/googleDrive.ts` | `updateFileContent()` 追加 |
| `src/hooks/useMarkdownEditor.ts` | **新規** 編集状態管理フック |
| `app/viewer.tsx` | 編集UI統合（トグル、保存、未保存警告、ショートカット） |
| `src/i18n/locales/{en,ja}.ts` | 編集関連の翻訳キー追加 |
| `src/hooks/index.ts`, `src/services/index.ts` | export追加 |

### 機能

- 編集/プレビュートグル（Google Driveファイルのみ）
- `Ctrl+S`/`Cmd+S`で保存、`E`で編集モード切替
- 未保存変更がある場合の離脱防止（beforeunload + 確認ダイアログ）
- 保存成功/失敗/再認証必要のステータスバー表示
- フォント設定（サイズ・ファミリー）が編集テキストエリアに反映

## Test plan

- [ ] Google Driveから.mdファイルを開く → プレビュー表示を確認
- [ ] 編集アイコンをタップ → テキストエリアに切り替わることを確認
- [ ] テキスト編集 → ファイル名横に黄色ドットが表示されることを確認
- [ ] 保存ボタンor`Cmd+S` → 「保存しました」メッセージを確認
- [ ] プレビューに切り替え → 編集内容が反映されていることを確認
- [ ] 編集中にブラウザバック → 確認ダイアログが表示されることを確認
- [ ] ローカルファイルを開いた場合 → 編集アイコンが表示されないことを確認
- [ ] `npx tsc --noEmit` で型チェック通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)