### PR TITLE
chore: Update domain to mark-drive.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Google Drive やローカルに保存された Markdown ファイルを安全に
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[Demo](https://my-md-viewer.vercel.app/) · [Documentation](./docs/)
+[Demo](https://mark-drive.com/) · [Documentation](./docs/)
 
 </div>
 

--- a/public/app-preview-light.svg
+++ b/public/app-preview-light.svg
@@ -14,7 +14,7 @@
 
   <!-- URL Bar -->
   <rect x="100" y="10" width="600" height="20" rx="4" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="120" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">md-viewer.vercel.app</text>
+  <text x="120" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">mark-drive.com</text>
 
   <!-- App Header -->
   <rect x="20" y="56" width="760" height="48" rx="8" fill="#f9fafb"/>

--- a/public/app-preview.svg
+++ b/public/app-preview.svg
@@ -13,7 +13,7 @@
 
   <!-- URL Bar -->
   <rect x="100" y="10" width="600" height="20" rx="4" fill="#1a1f2e"/>
-  <text x="120" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">md-viewer.vercel.app</text>
+  <text x="120" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">mark-drive.com</text>
 
   <!-- App Header -->
   <rect x="20" y="56" width="760" height="48" rx="8" fill="#252b3b"/>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -11,4 +11,4 @@ Allow: /third-party-licenses
 Disallow: /viewer
 Disallow: /search
 
-Sitemap: https://my-md-viewer.vercel.app/sitemap.xml
+Sitemap: https://mark-drive.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://my-md-viewer.vercel.app/</loc>
+    <loc>https://mark-drive.com/</loc>
     <priority>1.0</priority>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://my-md-viewer.vercel.app/about</loc>
+    <loc>https://mark-drive.com/about</loc>
     <priority>0.8</priority>
     <changefreq>monthly</changefreq>
   </url>
   <url>
-    <loc>https://my-md-viewer.vercel.app/privacy</loc>
+    <loc>https://mark-drive.com/privacy</loc>
     <priority>0.5</priority>
     <changefreq>yearly</changefreq>
   </url>
   <url>
-    <loc>https://my-md-viewer.vercel.app/terms</loc>
+    <loc>https://mark-drive.com/terms</loc>
     <priority>0.5</priority>
     <changefreq>yearly</changefreq>
   </url>
   <url>
-    <loc>https://my-md-viewer.vercel.app/license</loc>
+    <loc>https://mark-drive.com/license</loc>
     <priority>0.4</priority>
     <changefreq>yearly</changefreq>
   </url>
   <url>
-    <loc>https://my-md-viewer.vercel.app/third-party-licenses</loc>
+    <loc>https://mark-drive.com/third-party-licenses</loc>
     <priority>0.4</priority>
     <changefreq>monthly</changefreq>
   </url>


### PR DESCRIPTION
## Summary
- Vercel にリンクされたカスタムドメイン `mark-drive.com` に全 URL を更新
- `my-md-viewer.vercel.app` → `mark-drive.com` (README, sitemap, robots.txt)
- `md-viewer.vercel.app` → `mark-drive.com` (SVG プレビュー画像の URL バー表示)

## 変更対象 (5ファイル)
- `README.md` — Demo リンク
- `public/sitemap.xml` — 全6ページの URL
- `public/robots.txt` — Sitemap URL
- `public/app-preview.svg` — URL バー表示テキスト
- `public/app-preview-light.svg` — URL バー表示テキスト

## Test plan
- [x] grep で `vercel.app` の残存確認済み（`docs/setup.md` のプレースホルダーのみ許容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)