### PR TITLE
feat: CodeMirror 6 によるエディタのシンタックスハイライト化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,14 @@
       "name": "markdrive",
       "version": "2.0.0",
       "dependencies": {
+        "@codemirror/commands": "^6.10.2",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/search": "^6.6.0",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.12",
         "@expo/vector-icons": "^15.0.3",
+        "@lezer/highlight": "^1.2.3",
         "@react-navigation/native": "^7.1.8",
         "expo": "~54.0.32",
         "expo-constants": "~18.0.13",
@@ -1597,6 +1604,147 @@
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
+      "integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.3.tgz",
+      "integrity": "sha512-y3YkYhdnhjDBAe0VIA0c4wVoFOvnp8CnAvfLqi0TqotIv92wIlAAP7HELOpLBsKwjAX6W92rSflA6an/2zBvXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.39.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.12.tgz",
+      "integrity": "sha512-f+/VsHVn/kOA9lltk/GFzuYwVVAKmOnNjxbrhkk3tPHntFqjWeI2TbIXx006YkBkqC10wZ4NsnWXCQiFPeAISQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
@@ -2359,6 +2507,79 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
+      "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
       "version": "0.6.3",
@@ -4476,6 +4697,12 @@
       "dependencies": {
         "layout-base": "^1.0.0"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -10939,6 +11166,12 @@
       "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==",
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -11989,6 +12222,12 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,14 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.2",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.1",
+    "@codemirror/search": "^6.6.0",
+    "@codemirror/state": "^6.5.4",
+    "@codemirror/view": "^6.39.12",
     "@expo/vector-icons": "^15.0.3",
+    "@lezer/highlight": "^1.2.3",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.32",
     "expo-constants": "~18.0.13",

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -1,0 +1,202 @@
+/**
+ * CodeMirrorEditor - CodeMirror 6 based Markdown editor with syntax highlighting
+ */
+
+import React, { useRef, useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { EditorState } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { searchKeymap } from '@codemirror/search';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { syntaxHighlighting, HighlightStyle } from '@codemirror/language';
+import { tags } from '@lezer/highlight';
+import { useTheme } from '../../hooks/useTheme';
+import { useFontSettings, fontSizeMultipliers } from '../../contexts/FontSettingsContext';
+import { spacing, borderRadius, fontSize as themeFontSize } from '../../theme';
+
+interface CodeMirrorEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSave?: () => void;
+  autoFocus?: boolean;
+}
+
+export function CodeMirrorEditor({ value, onChange, onSave, autoFocus }: CodeMirrorEditorProps) {
+  const { colors, mode } = useTheme();
+  const { settings: fontSettings } = useFontSettings();
+  const editorRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(onChange);
+  const onSaveRef = useRef(onSave);
+
+  // Keep refs up to date
+  onChangeRef.current = onChange;
+  onSaveRef.current = onSave;
+
+  // Recreate editor when theme or font settings change
+  useEffect(() => {
+    if (!editorRef.current) return;
+
+    const computedFontSize = themeFontSize.base * fontSizeMultipliers[fontSettings.fontSize];
+
+    const highlightStyle = HighlightStyle.define([
+      { tag: tags.heading1, color: colors.accent, fontWeight: 'bold' },
+      { tag: tags.heading2, color: colors.accent, fontWeight: 'bold' },
+      { tag: tags.heading3, color: colors.accent },
+      { tag: tags.heading4, color: colors.accent },
+      { tag: tags.heading5, color: colors.accent },
+      { tag: tags.heading6, color: colors.accent },
+      { tag: tags.emphasis, fontStyle: 'italic', color: colors.textSecondary },
+      { tag: tags.strong, fontWeight: 'bold', color: colors.warning },
+      { tag: tags.link, color: colors.accent, textDecoration: 'underline' },
+      { tag: tags.url, color: colors.accent, textDecoration: 'underline' },
+      { tag: tags.monospace, color: colors.warning, backgroundColor: colors.bgTertiary },
+      { tag: tags.quote, color: colors.textMuted, fontStyle: 'italic' },
+      { tag: tags.meta, color: colors.textMuted },
+      { tag: tags.processingInstruction, color: colors.textMuted },
+    ]);
+
+    const customTheme = EditorView.theme({
+      '&': {
+        backgroundColor: colors.bgSecondary,
+        color: colors.textPrimary,
+        fontSize: `${computedFontSize}px`,
+        fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
+        flex: '1',
+        height: '100%',
+      },
+      '.cm-content': {
+        padding: `${spacing.md}px`,
+        caretColor: colors.accent,
+        lineHeight: '1.7',
+      },
+      '.cm-gutters': {
+        backgroundColor: colors.bgTertiary,
+        color: colors.textMuted,
+        border: 'none',
+      },
+      '.cm-activeLineGutter': {
+        backgroundColor: colors.accentMuted,
+      },
+      '.cm-activeLine': {
+        backgroundColor: colors.accentMuted,
+      },
+      '&.cm-focused .cm-cursor': {
+        borderLeftColor: colors.accent,
+        borderLeftWidth: '2px',
+      },
+      '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
+        backgroundColor: `${colors.accent}30`,
+      },
+      '.cm-scroller': {
+        overflow: 'auto',
+        flex: '1',
+        fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
+      },
+      '&.cm-focused': {
+        outline: 'none',
+      },
+    });
+
+    // Preserve current document content if view exists
+    const currentContent = viewRef.current
+      ? viewRef.current.state.doc.toString()
+      : value;
+
+    // Destroy previous view
+    if (viewRef.current) {
+      viewRef.current.destroy();
+      viewRef.current = null;
+    }
+
+    const extensions = [
+      customTheme,
+      markdown({ base: markdownLanguage }),
+      syntaxHighlighting(highlightStyle),
+      history(),
+      keymap.of([
+        ...defaultKeymap,
+        ...historyKeymap,
+        ...searchKeymap,
+        {
+          key: 'Mod-s',
+          run: () => {
+            onSaveRef.current?.();
+            return true;
+          },
+        },
+      ]),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          onChangeRef.current(update.state.doc.toString());
+        }
+      }),
+      EditorView.lineWrapping,
+      EditorState.tabSize.of(2),
+    ];
+
+    const state = EditorState.create({
+      doc: currentContent,
+      extensions,
+    });
+
+    const view = new EditorView({
+      state,
+      parent: editorRef.current,
+    });
+
+    viewRef.current = view;
+
+    if (autoFocus) {
+      view.focus();
+    }
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+  }, [mode, fontSettings.fontSize, colors]);
+
+  // Sync external value changes
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    const currentContent = view.state.doc.toString();
+    if (currentContent !== value) {
+      view.dispatch({
+        changes: {
+          from: 0,
+          to: currentContent.length,
+          insert: value,
+        },
+      });
+    }
+  }, [value]);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          borderColor: colors.border,
+          borderLeftColor: colors.accent,
+        },
+      ]}
+    >
+      <div ref={editorRef} style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    margin: spacing.sm,
+    borderWidth: 1,
+    borderLeftWidth: 3,
+    borderRadius: borderRadius.md,
+    overflow: 'hidden',
+  },
+});

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -50,6 +50,9 @@ export const en = {
     unsavedChanges: 'You have unsaved changes. Discard them?',
     save: 'Save',
     reauthRequired: 'Please sign out and sign in again to enable editing',
+    linesCount: '{lines} lines',
+    charsCount: '{chars} chars',
+    unsavedLabel: 'Unsaved changes',
   },
 
   // Search Screen
@@ -309,6 +312,9 @@ export type Translations = {
     unsavedChanges: string;
     save: string;
     reauthRequired: string;
+    linesCount: string;
+    charsCount: string;
+    unsavedLabel: string;
   };
   search: {
     placeholder: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -52,6 +52,9 @@ export const ja: Translations = {
     unsavedChanges: '未保存の変更があります。破棄しますか？',
     save: '保存',
     reauthRequired: '編集を有効にするには、サインアウトして再度サインインしてください',
+    linesCount: '{lines} 行',
+    charsCount: '{chars} 文字',
+    unsavedLabel: '未保存の変更',
   },
 
   // Search Screen


### PR DESCRIPTION
## Summary

- TextInput (textarea) を CodeMirror 6 に置き換え、Markdown シンタックスハイライトを実現
- 見出し(accent色)、太字(黄色)、リンク、インラインコード、引用等のハイライト対応
- ダーク/ライトテーマ連動、フォントサイズ設定連動、Ctrl+S 保存、undo/redo、検索対応
- フッターステータスバー(行数・文字数カウント、保存状態表示)を追加
- Edit/Preview セグメントコントロール UI を改善

## Test plan

- [ ] ブラウザでエディタ画面を開き、ダーク/ライトテーマで表示確認
- [ ] `#` 見出しがアクセント色で表示されること
- [ ] `**太字**` が黄色で表示されること
- [ ] コードブロック、リンク、引用等もハイライトされること
- [ ] マウスホイールでスクロールが正常に動作すること
- [ ] Ctrl+S で保存が動作すること
- [ ] フッターの行数・文字数カウントが正常であること
- [ ] テーマ切替時にエディタ色が追従すること
- [ ] undo/redo (Ctrl+Z / Ctrl+Shift+Z) が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)