### PR TITLE
feat: Add system theme option following OS color scheme

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -31,7 +31,7 @@ const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const MENU_WIDTH = Math.min(320, SCREEN_WIDTH * 0.85);
 
 export default function HomeScreen() {
-  const { colors, mode: themeMode, setTheme } = useTheme();
+  const { colors, mode: themeMode, resolvedMode, setTheme } = useTheme();
   const { t, language, setLanguage } = useLanguage();
   const { settings: fontSettings, setFontSize, setFontFamily } = useFontSettings();
   const {
@@ -249,7 +249,7 @@ export default function HomeScreen() {
               <View style={[styles.previewContainer, { backgroundColor: colors.bgTertiary }]}>
                 {Platform.OS === 'web' && (
                   <img
-                    src={themeMode === 'dark' ? '/app-preview.svg' : '/app-preview-light.svg'}
+                    src={resolvedMode === 'dark' ? '/app-preview.svg' : '/app-preview-light.svg'}
                     alt="MarkDrive Preview"
                     style={{ width: '100%', height: 'auto', borderRadius: 8 }}
                   />
@@ -533,6 +533,19 @@ export default function HomeScreen() {
                   <Ionicons name="moon-outline" size={18} color={themeMode === 'dark' ? colors.accent : colors.textSecondary} />
                   <Text style={[styles.menuOptionText, { color: themeMode === 'dark' ? colors.accent : colors.textSecondary }]}>
                     {t.settings.dark}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.menuOption,
+                    styles.menuOptionWide,
+                    { backgroundColor: themeMode === 'system' ? colors.accentMuted : colors.bgTertiary }
+                  ]}
+                  onPress={() => setTheme('system')}
+                >
+                  <Ionicons name="phone-portrait-outline" size={18} color={themeMode === 'system' ? colors.accent : colors.textSecondary} />
+                  <Text style={[styles.menuOptionText, { color: themeMode === 'system' ? colors.accent : colors.textSecondary }]}>
+                    {t.settings.system}
                   </Text>
                 </TouchableOpacity>
               </View>

--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -34,7 +34,7 @@ type ViewerParams = {
 };
 
 export default function ViewerScreen() {
-  const { colors, mode: themeMode, setTheme } = useTheme();
+  const { colors, mode: themeMode, resolvedMode, setTheme } = useTheme();
   const { t, language, setLanguage } = useLanguage();
   const { settings: fontSettings, setFontSize, setFontFamily } = useFontSettings();
   const params = useLocalSearchParams<ViewerParams>();
@@ -510,7 +510,7 @@ export default function ViewerScreen() {
               showsVerticalScrollIndicator={!isFullscreen}
             >
               <View style={isFullscreen ? [styles.contentContainer, styles.fullscreenCard] : styles.contentContainer}>
-                <MarkdownRenderer content={content!} onLinkPress={handleLinkPress} themeMode={themeMode} />
+                <MarkdownRenderer content={content!} onLinkPress={handleLinkPress} themeMode={resolvedMode} />
               </View>
             </ScrollView>
           </Pressable>
@@ -659,6 +659,19 @@ export default function ViewerScreen() {
                   <Ionicons name="moon-outline" size={18} color={themeMode === 'dark' ? colors.accent : colors.textSecondary} />
                   <Text style={[styles.dialogOptionText, { color: themeMode === 'dark' ? colors.accent : colors.textSecondary }]}>
                     {t.settings.dark}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.dialogOption,
+                    styles.dialogOptionWide,
+                    { backgroundColor: themeMode === 'system' ? colors.accentMuted : colors.bgTertiary }
+                  ]}
+                  onPress={() => setTheme('system')}
+                >
+                  <Ionicons name="phone-portrait-outline" size={18} color={themeMode === 'system' ? colors.accent : colors.textSecondary} />
+                  <Text style={[styles.dialogOptionText, { color: themeMode === 'system' ? colors.accent : colors.textSecondary }]}>
+                    {t.settings.system}
                   </Text>
                 </TouchableOpacity>
               </View>

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -23,7 +23,7 @@ interface CodeMirrorEditorProps {
 }
 
 export function CodeMirrorEditor({ value, onChange, onSave, autoFocus }: CodeMirrorEditorProps) {
-  const { colors, mode } = useTheme();
+  const { colors, resolvedMode } = useTheme();
   const { settings: fontSettings } = useFontSettings();
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -156,7 +156,7 @@ export function CodeMirrorEditor({ value, onChange, onSave, autoFocus }: CodeMir
       view.destroy();
       viewRef.current = null;
     };
-  }, [mode, fontSettings.fontSize, colors]);
+  }, [resolvedMode, fontSettings.fontSize, colors]);
 
   // Sync external value changes
   useEffect(() => {

--- a/src/components/markdown/MarkdownRenderer.web.tsx
+++ b/src/components/markdown/MarkdownRenderer.web.tsx
@@ -382,9 +382,9 @@ interface ExtendedMarkdownRendererProps extends MarkdownRendererProps {
 }
 
 export function MarkdownRenderer({ content, onLinkPress, themeMode: propThemeMode }: ExtendedMarkdownRendererProps) {
-  const { colors, mode: contextMode } = useTheme();
+  const { colors, resolvedMode: contextResolvedMode } = useTheme();
   const { settings: fontSettings } = useFontSettings();
-  const themeMode = propThemeMode ?? contextMode;
+  const themeMode = propThemeMode ?? contextResolvedMode;
   const isDark = themeMode === 'dark';
 
   const webStyles = useMemo(() => generateWebStyles(colors, isDark, fontSettings), [colors, isDark, fontSettings]);

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useState, useEffect, useCallback, useMemo, ReactN
 import { colors as darkColors } from '../theme/colors';
 import { lightColors } from '../theme/lightColors';
 
-export type ThemeMode = 'dark' | 'light';
+export type ThemeMode = 'dark' | 'light' | 'system';
 
 // Use a more flexible type that works with both color schemes
 export interface ThemeColors {
@@ -33,6 +33,7 @@ export interface ThemeColors {
 
 export interface ThemeContextValue {
   mode: ThemeMode;
+  resolvedMode: 'dark' | 'light';
   colors: ThemeColors;
   toggleTheme: () => void;
   setTheme: (mode: ThemeMode) => void;
@@ -46,16 +47,37 @@ interface ThemeProviderProps {
   children: ReactNode;
 }
 
+function getSystemColorScheme(): 'dark' | 'light' {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'dark';
+}
+
 export function ThemeProvider({ children }: ThemeProviderProps) {
-  const [mode, setMode] = useState<ThemeMode>('dark');
+  const [mode, setMode] = useState<ThemeMode>('system');
+  const [systemScheme, setSystemScheme] = useState<'dark' | 'light'>(getSystemColorScheme);
   const [isInitialized, setIsInitialized] = useState(false);
+
+  // Listen for OS color scheme changes
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => {
+      setSystemScheme(e.matches ? 'dark' : 'light');
+    };
+
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, []);
 
   // Initialize theme from localStorage
   useEffect(() => {
     if (typeof window !== 'undefined') {
       try {
         const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored === 'light' || stored === 'dark') {
+        if (stored === 'light' || stored === 'dark' || stored === 'system') {
           setMode(stored);
         }
       } catch (e) {
@@ -76,6 +98,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
   }, [mode, isInitialized]);
 
+  const resolvedMode: 'dark' | 'light' = mode === 'system' ? systemScheme : mode;
+
   const toggleTheme = useCallback(() => {
     setMode((prev) => (prev === 'dark' ? 'light' : 'dark'));
   }, []);
@@ -85,17 +109,18 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   }, []);
 
   const colors = useMemo(() => {
-    return mode === 'dark' ? darkColors : lightColors;
-  }, [mode]);
+    return resolvedMode === 'dark' ? darkColors : lightColors;
+  }, [resolvedMode]);
 
   const value = useMemo(
     () => ({
       mode,
+      resolvedMode,
       colors,
       toggleTheme,
       setTheme,
     }),
-    [mode, colors, toggleTheme, setTheme]
+    [mode, resolvedMode, colors, toggleTheme, setTheme]
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -151,6 +151,7 @@ export const en = {
     theme: 'Theme',
     light: 'Light',
     dark: 'Dark',
+    system: 'System',
     language: 'Language',
   },
 
@@ -385,6 +386,7 @@ export type Translations = {
     theme: string;
     light: string;
     dark: string;
+    system: string;
     language: string;
   };
   fontSettings: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -153,6 +153,7 @@ export const ja: Translations = {
     theme: 'テーマ',
     light: 'ライト',
     dark: 'ダーク',
+    system: 'システム',
     language: '言語',
   },
 


### PR DESCRIPTION
## Summary

- テーマ設定に「システム」オプションを追加。OS のダーク/ライトモード設定に自動追従する
- `matchMedia('prefers-color-scheme')` + `addEventListener('change')` でリアルタイム検知
- デフォルトのテーマを `dark` → `system` に変更（既存ユーザーは localStorage の値が優先）

## Changes

- `ThemeContext`: `ThemeMode` に `'system'` 追加、`resolvedMode` の導入、OS カラースキーム検知ロジック
- `en.ts` / `ja.ts`: 翻訳キー `settings.system` 追加
- `viewer.tsx` / `index.tsx`: テーマ選択 UI に「システム」ボタン追加
- `CodeMirrorEditor` / `MarkdownRenderer`: `resolvedMode` を使用するように修正

## Test plan

- [ ] Light / Dark / System の 3 つのテーマ切替が動作すること
- [ ] System 選択時に OS 設定変更で色がリアルタイムに追従すること
- [ ] ページリロード後もテーマ設定が保持されること
- [ ] `npx tsc --noEmit` で型エラーがないこと（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)