### PR TITLE
fix: Add drive.readonly scope to fix file listing and search

### DIFF
--- a/src/hooks/useGoogleAuth.web.ts
+++ b/src/hooks/useGoogleAuth.web.ts
@@ -18,8 +18,8 @@ import { storage } from '../services/storage';
 const API_KEY = process.env.EXPO_PUBLIC_GOOGLE_API_KEY || '';
 const CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID || '';
 
-// Google API のスコープ
-const SCOPES = 'https://www.googleapis.com/auth/drive.file';
+// Google API のスコープ（読み取り + アプリ作成ファイルの書き込み）
+const SCOPES = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file';
 
 // ストレージのキー
 const TOKEN_KEY = 'googleDriveAccessToken';


### PR DESCRIPTION
## Summary
- OAuthスコープに `drive.readonly` を追加し、ユーザーのDrive内の既存Markdownファイルの一覧表示・検索を可能にした
- `drive.file` スコープのみでは、アプリ自身が作成したファイルにしかアクセスできず、ログイン後にファイルが0件になっていた
- 編集・保存機能のために `drive.file` スコープも維持

## Test plan
- [ ] ログイン後、最近のMarkdownファイル一覧が表示されることを確認
- [ ] 検索でDrive内のMarkdownファイルがヒットすることを確認
- [ ] ファイルの編集・保存が引き続き動作することを確認
- [ ] 既存ユーザーは再ログイン（再認可）で新しいスコープが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)