### PR TITLE
README を OGP ヒーロー画像中心にリデザイン

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 [mark-drive.com](https://mark-drive.com/)
 
+<br />
+
 ## クイックスタート
 
 ```bash
@@ -22,6 +24,8 @@ http://localhost:8081 を開いて使えます。
 
 > Google Drive 連携には API キーの設定が必要です。 [セットアップガイド](./docs/setup.md)
 
+<br />
+
 ## ドキュメント
 
 | | |
@@ -32,6 +36,8 @@ http://localhost:8081 を開いて使えます。
 | [機能仕様](./docs/features.md) | 各機能の詳細仕様 |
 | [開発ガイド](./docs/development.md) | 開発環境・テスト・デプロイ |
 | [プライバシー](./docs/privacy.md) | プライバシーとセキュリティ |
+
+<br />
 
 ## コントリビュート
 


### PR DESCRIPTION
## Summary
- OGP 画像 (`og-image.png`) をヒーローバナーとして配置し、視覚的にリッチな README に刷新
- 特徴・技術スタック・ライセンスセクションを削除（docs へのリンクで辿れるため）
- ドキュメントリンクをテーブルで整理してコンパクトに

## Test plan
- [ ] GitHub 上で README のレンダリングを確認（OGP 画像が表示されること）
- [ ] 各ドキュメントリンクが正しく遷移すること
- [ ] mark-drive.com リンクが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)