### PR TITLE
ランディングページのセクション間隔拡大 + ヘッダー透過

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -177,7 +177,7 @@ export default function HomeScreen() {
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
       {/* Landing Header - Settings bar for non-authenticated users */}
       {!isAuthenticated && (
-        <View style={[styles.landingHeader, { borderBottomColor: colors.border, backgroundColor: colors.bgSecondary }]}>
+        <View style={[styles.landingHeader]}>
           <View style={styles.headerActions}>
             <LanguageToggle />
             <ThemeToggle />
@@ -786,12 +786,16 @@ const styles = StyleSheet.create({
     gap: spacing.md,
   },
   landingHeader: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-end',
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
-    borderBottomWidth: 1,
   },
   headerActions: {
     flexDirection: 'row',
@@ -845,6 +849,8 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   heroRow: {
+    minHeight: 800,
+    justifyContent: 'center',
     paddingVertical: spacing.xl,
     gap: spacing.xl,
   },
@@ -930,7 +936,8 @@ const styles = StyleSheet.create({
   },
   // How it Works
   howItWorksSection: {
-    marginTop: spacing['2xl'],
+    minHeight: 800,
+    justifyContent: 'center',
     alignItems: 'center',
   },
   stepsRow: {
@@ -981,7 +988,8 @@ const styles = StyleSheet.create({
 
   // Features
   featuresSection: {
-    marginTop: spacing['2xl'],
+    minHeight: 800,
+    justifyContent: 'center',
   },
   featuresGrid: {
     flexDirection: 'row',
@@ -1030,7 +1038,8 @@ const styles = StyleSheet.create({
 
   // Stats / Tech
   techSection: {
-    marginTop: spacing['2xl'],
+    minHeight: 800,
+    justifyContent: 'center',
     alignItems: 'center',
   },
   techChips: {
@@ -1075,13 +1084,15 @@ const styles = StyleSheet.create({
 
   // Benefits
   benefitsSection: {
-    marginTop: spacing['2xl'],
+    minHeight: 800,
+    justifyContent: 'center',
     gap: spacing.md,
   },
 
   // Closing CTA
   closingCtaSection: {
-    marginTop: spacing['2xl'],
+    minHeight: 800,
+    justifyContent: 'center',
     padding: spacing.xl,
     alignItems: 'center',
   },


### PR DESCRIPTION
## Summary
- 各セクション（Hero / How it Works / Features / Tech / Benefits / CTA）に `minHeight: 800` を設定し、1セクション=1画面のゆとりあるレイアウトに変更
- 未ログイン時のランディングヘッダーを `position: absolute` の透過オーバーレイに変更し、背景色・ボーダーを削除

## Test plan
- [ ] 未ログイン状態でランディングページを表示し、各セクションが十分な高さを持つこと
- [ ] ヘッダー（言語・テーマ切り替え）が透過でコンテンツに重なること
- [ ] ログイン後のヘッダーは従来通り表示されること
- [ ] モバイル幅でもレイアウトが崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)