### PR TITLE
モバイル編集画面の UX 改善

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -10,7 +10,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
 
         {/* Primary Meta Tags */}
         <title>MarkDrive - Beautiful Markdown Viewer for Google Drive</title>

--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -310,16 +310,16 @@ export default function ViewerScreen() {
       edges={isFullscreen ? [] : ['top']}
     >
       {/* Header */}
-      {(!isFullscreen || showHeader) && (
+      {(!isFullscreen || showHeader || editor.mode === 'edit') && (
         <Animated.View
           style={[
             styles.header,
             {
               borderBottomColor: colors.border,
               backgroundColor: colors.bgSecondary,
-              opacity: isFullscreen ? headerOpacity : 1,
+              opacity: isFullscreen && editor.mode !== 'edit' ? headerOpacity : 1,
             },
-            isFullscreen && styles.fullscreenHeader,
+            isFullscreen && editor.mode !== 'edit' && styles.fullscreenHeader,
           ]}
         >
           <TouchableOpacity style={styles.backButton} onPress={isFullscreen ? exitFullscreen : handleBack}>
@@ -823,10 +823,12 @@ const styles = StyleSheet.create({
   editorFooter: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
+    gap: spacing.md,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
     borderTopWidth: 1,
+    flexWrap: 'wrap',
   },
   editorFooterText: {
     fontSize: fontSize.xs,


### PR DESCRIPTION
## Summary
- viewport に `maximum-scale=1` を追加し、iOS Safari でエディタにフォーカスした際の自動ズームを防止
- 編集モード中はフルスクリーンでもヘッダーを常に表示し、戻れなくなる問題を修正
- エディタフッター (lines/chars) をセンタリング + `flexWrap` でモバイルでのテキスト被りを修正

## Test plan
- [ ] モバイルで編集画面に入った際にページがズームしないこと
- [ ] 編集モードでフルスクリーンにしてもヘッダー（戻るボタン）が表示されること
- [ ] エディタフッターの lines/chars テキストが被らずセンタリングされること
- [ ] プレビューモードのフルスクリーンは従来通りタップでヘッダー表示/非表示が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)