### PR TITLE
静的ビルド時のレイアウト崩れ修正

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -36,7 +36,8 @@ export default function HomeScreen() {
   const { colors, mode: themeMode, resolvedMode, setTheme } = useTheme();
   const { t, language, setLanguage } = useLanguage();
   const { width: _windowWidth } = useWindowDimensions();
-  const windowWidth = _windowWidth || (Platform.OS === 'web' && typeof window !== 'undefined' ? window.innerWidth : 0);
+  const SSR_DEFAULT_WIDTH = 1024;
+  const windowWidth = _windowWidth || (Platform.OS === 'web' && typeof window !== 'undefined' ? window.innerWidth : SSR_DEFAULT_WIDTH);
   const isDesktop = windowWidth >= 768;
   const { settings: fontSettings, setFontSize, setFontFamily } = useFontSettings();
   const {


### PR DESCRIPTION
## Summary
- `expo export` の静的レンダリング（Node.js）では `window` が存在せず `windowWidth` が 0 になり、全セクションがモバイルレイアウトで HTML に焼き込まれていた
- SSR 時のデフォルト幅を 1024px に変更し、デスクトップレイアウトで静的 HTML を生成するよう修正

## Test plan
- [ ] `npm run build` で静的ビルドし、生成された HTML がデスクトップレイアウトであること
- [ ] デプロイ後 mark-drive.com でレイアウトが正常に表示されること
- [ ] モバイル実機でもクライアント hydration 後に正しくモバイルレイアウトに切り替わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)