### PR TITLE
feat: モバイル用プレビュー画像追加 + SVG配色統一

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -35,9 +35,14 @@ const MENU_WIDTH = Math.min(320, SCREEN_WIDTH * 0.85);
 export default function HomeScreen() {
   const { colors, mode: themeMode, resolvedMode, setTheme } = useTheme();
   const { t, language, setLanguage } = useLanguage();
-  const { width: _windowWidth } = useWindowDimensions();
-  const SSR_DEFAULT_WIDTH = 1024;
-  const windowWidth = _windowWidth || (Platform.OS === 'web' && typeof window !== 'undefined' ? window.innerWidth : SSR_DEFAULT_WIDTH);
+  const [windowWidth, setWindowWidth] = useState(0);
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+    setWindowWidth(window.innerWidth);
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
   const isDesktop = windowWidth >= 768;
   const { settings: fontSettings, setFontSize, setFontFamily } = useFontSettings();
   const {
@@ -278,14 +283,22 @@ export default function HomeScreen() {
               </View>
 
               {/* Right: Preview image */}
-              <View style={styles.heroRight}>
-                <View style={[styles.previewContainer, { borderColor: colors.borderLight, ...shadows.md }]}>
+              <View style={isDesktop ? styles.heroRight : styles.heroRightMobile}>
+                <View style={isDesktop ? [styles.previewContainer, { borderColor: colors.borderLight, ...shadows.md }] : styles.previewContainerMobile}>
                   {Platform.OS === 'web' && (
-                    <img
-                      src={resolvedMode === 'dark' ? '/app-preview.svg' : '/app-preview-light.svg'}
-                      alt="MarkDrive Preview"
-                      style={{ width: '100%', height: 'auto', borderRadius: 8 }}
-                    />
+                    isDesktop ? (
+                      <img
+                        src={resolvedMode === 'dark' ? '/app-preview.svg' : '/app-preview-light.svg'}
+                        alt="MarkDrive Preview"
+                        style={{ width: '100%', height: 'auto', borderRadius: 8 }}
+                      />
+                    ) : (
+                      <img
+                        src={resolvedMode === 'dark' ? '/app-preview-mobile.svg' : '/app-preview-mobile-light.svg'}
+                        alt="MarkDrive Mobile Preview"
+                        style={{ width: '100%', height: 'auto' }}
+                      />
+                    )
                   )}
                 </View>
               </View>
@@ -872,6 +885,13 @@ const styles = StyleSheet.create({
   },
   heroRight: {
     flex: 1,
+    width: '100%',
+  },
+  heroRightMobile: {
+    width: '100%',
+    marginTop: spacing.xl,
+  },
+  previewContainerMobile: {
     width: '100%',
   },
   heroLogoRow: {

--- a/public/app-preview-light.svg
+++ b/public/app-preview-light.svg
@@ -1,11 +1,11 @@
-<svg width="800" height="500" viewBox="0 0 800 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Browser Frame -->
-  <rect x="0" y="0" width="800" height="500" rx="12" fill="#ffffff"/>
-  <rect x="0" y="0" width="800" height="500" rx="12" stroke="#e5e7eb" stroke-width="1"/>
+  <rect x="0" y="0" width="500" height="500" rx="12" fill="#ffffff"/>
+  <rect x="0" y="0" width="500" height="500" rx="12" stroke="#e5e7eb" stroke-width="1"/>
 
   <!-- Title Bar -->
-  <rect x="0" y="0" width="800" height="40" rx="12" fill="#f9fafb"/>
-  <rect x="0" y="28" width="800" height="12" fill="#f9fafb"/>
+  <rect x="0" y="0" width="500" height="40" rx="12" fill="#f8f8fd"/>
+  <rect x="0" y="28" width="500" height="12" fill="#f8f8fd"/>
 
   <!-- Window Controls -->
   <circle cx="20" cy="20" r="6" fill="#ff5f57"/>
@@ -13,39 +13,40 @@
   <circle cx="60" cy="20" r="6" fill="#28c840"/>
 
   <!-- URL Bar -->
-  <rect x="100" y="10" width="600" height="20" rx="4" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="120" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">mark-drive.com</text>
+  <rect x="90" y="10" width="340" height="20" rx="4" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="110" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">mark-drive.com</text>
 
   <!-- App Header -->
-  <rect x="20" y="56" width="760" height="48" rx="8" fill="#f9fafb"/>
-  <text x="40" y="86" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#1f2937">README.md</text>
+  <rect x="20" y="56" width="460" height="48" rx="8" fill="#f8f8fd"/>
+  <text x="40" y="86" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#1a1b2e">README.md</text>
 
   <!-- Content Area -->
-  <rect x="20" y="120" width="760" height="360" rx="8" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+  <rect x="20" y="120" width="460" height="360" rx="8" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
 
   <!-- Markdown Content -->
   <!-- H1 -->
-  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#111827"># Welcome to MarkDrive</text>
+  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="22" font-weight="700" fill="#1a1b2e"># Welcome to MarkDrive</text>
 
   <!-- Paragraph -->
-  <text x="40" y="200" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">A beautiful Markdown viewer for Google Drive files.</text>
+  <text x="40" y="196" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">A beautiful Markdown viewer</text>
+  <text x="40" y="214" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">for Google Drive files.</text>
 
   <!-- H2 -->
-  <text x="40" y="250" font-family="system-ui, sans-serif" font-size="18" font-weight="600" fill="#1f2937">## Features</text>
+  <text x="40" y="254" font-family="system-ui, sans-serif" font-size="17" font-weight="600" fill="#1a1b2e">## Features</text>
 
   <!-- List items -->
   <circle cx="50" cy="285" r="3" fill="#6366f1"/>
-  <text x="65" y="290" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">Google Drive integration</text>
+  <text x="65" y="290" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Google Drive integration</text>
 
   <circle cx="50" cy="315" r="3" fill="#6366f1"/>
-  <text x="65" y="320" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">Beautiful syntax highlighting</text>
+  <text x="65" y="320" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Beautiful syntax highlighting</text>
 
   <circle cx="50" cy="345" r="3" fill="#6366f1"/>
-  <text x="65" y="350" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">Mermaid diagram support</text>
+  <text x="65" y="350" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Mermaid diagram support</text>
 
   <!-- Code Block -->
-  <rect x="40" y="375" width="720" height="80" rx="6" fill="#f6f8fa"/>
-  <text x="55" y="400" font-family="monospace" font-size="12" fill="#116329">```javascript</text>
+  <rect x="40" y="375" width="420" height="80" rx="6" fill="#f6f8fa"/>
+  <text x="55" y="400" font-family="monospace" font-size="12" fill="#6e7781">```javascript</text>
   <text x="55" y="420" font-family="monospace" font-size="12" fill="#24292f">const viewer = new MDViewer();</text>
   <text x="55" y="440" font-family="monospace" font-size="12" fill="#24292f">viewer.render(markdown);</text>
 
@@ -56,5 +57,5 @@
       <stop offset="1" stop-color="#ffffff" stop-opacity="0.8"/>
     </linearGradient>
   </defs>
-  <rect x="0" y="400" width="800" height="100" fill="url(#fadeBottomLight)"/>
+  <rect x="0" y="400" width="500" height="100" fill="url(#fadeBottomLight)"/>
 </svg>

--- a/public/app-preview-mobile-light.svg
+++ b/public/app-preview-mobile-light.svg
@@ -1,0 +1,70 @@
+<svg width="320" height="640" viewBox="0 0 320 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Phone Frame -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="#ffffff" stroke="#e5e7eb" stroke-width="2"/>
+
+  <!-- Status Bar -->
+  <text x="24" y="24" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1a1b2e">9:41</text>
+  <circle cx="280" cy="19" r="4" fill="#1a1b2e"/>
+  <rect x="254" y="16" width="16" height="7" rx="2" fill="#1a1b2e"/>
+  <rect x="236" y="14" width="12" height="10" rx="1" fill="none" stroke="#1a1b2e" stroke-width="1.5"/>
+
+  <!-- App Header -->
+  <rect x="12" y="40" width="296" height="40" rx="8" fill="#f8f8fd"/>
+  <text x="28" y="65" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1a1b2e">README.md</text>
+
+  <!-- Content Area -->
+  <rect x="12" y="92" width="296" height="536" rx="8" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+
+  <!-- Markdown Content -->
+  <!-- H1 -->
+  <text x="24" y="124" font-family="system-ui, sans-serif" font-size="20" font-weight="700" fill="#1a1b2e"># Welcome to MarkDrive</text>
+
+  <!-- Paragraph -->
+  <text x="24" y="156" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">A beautiful Markdown viewer</text>
+  <text x="24" y="172" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">for Google Drive files.</text>
+
+  <!-- H2 -->
+  <text x="24" y="210" font-family="system-ui, sans-serif" font-size="16" font-weight="600" fill="#1a1b2e">## Features</text>
+
+  <!-- List items -->
+  <circle cx="32" cy="240" r="3" fill="#6366f1"/>
+  <text x="44" y="244" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">Google Drive integration</text>
+
+  <circle cx="32" cy="266" r="3" fill="#6366f1"/>
+  <text x="44" y="270" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">Syntax highlighting</text>
+
+  <circle cx="32" cy="292" r="3" fill="#6366f1"/>
+  <text x="44" y="296" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">Mermaid diagram support</text>
+
+  <!-- Code Block -->
+  <rect x="24" y="316" width="272" height="72" rx="6" fill="#f6f8fa"/>
+  <text x="36" y="338" font-family="monospace" font-size="11" fill="#6e7781">```javascript</text>
+  <text x="36" y="356" font-family="monospace" font-size="11" fill="#24292f">const viewer = new MDViewer();</text>
+  <text x="36" y="374" font-family="monospace" font-size="11" fill="#24292f">viewer.render(markdown);</text>
+
+  <!-- Table -->
+  <rect x="24" y="408" width="272" height="24" rx="4" fill="#f0f0f8"/>
+  <text x="36" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1a1b2e">Feature</text>
+  <text x="180" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1a1b2e">Status</text>
+  <line x1="24" y1="432" x2="296" y2="432" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="36" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">GFM</text>
+  <text x="180" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#059669">Ready</text>
+  <line x1="24" y1="460" x2="296" y2="460" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="36" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">Mermaid</text>
+  <text x="180" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#059669">Ready</text>
+  <line x1="24" y1="488" x2="296" y2="488" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="36" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">KaTeX</text>
+  <text x="180" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#059669">Ready</text>
+
+  <!-- Decorative gradient overlay -->
+  <defs>
+    <linearGradient id="fadeMobileLight" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0.75" stop-color="#ffffff" stop-opacity="0"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0.9"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="540" width="320" height="100" rx="36" fill="url(#fadeMobileLight)"/>
+
+  <!-- Home Indicator -->
+  <rect x="110" y="618" width="100" height="4" rx="2" fill="#d1d5db"/>
+</svg>

--- a/public/app-preview-mobile.svg
+++ b/public/app-preview-mobile.svg
@@ -1,0 +1,70 @@
+<svg width="320" height="640" viewBox="0 0 320 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Phone Frame -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="#0a0b14" stroke="#1e2038" stroke-width="2"/>
+
+  <!-- Status Bar -->
+  <text x="24" y="24" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#e2e8f0">9:41</text>
+  <circle cx="280" cy="19" r="4" fill="#e2e8f0"/>
+  <rect x="254" y="16" width="16" height="7" rx="2" fill="#e2e8f0"/>
+  <rect x="236" y="14" width="12" height="10" rx="1" fill="none" stroke="#e2e8f0" stroke-width="1.5"/>
+
+  <!-- App Header -->
+  <rect x="12" y="40" width="296" height="40" rx="8" fill="#111320"/>
+  <text x="28" y="65" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#e2e8f0">README.md</text>
+
+  <!-- Content Area -->
+  <rect x="12" y="92" width="296" height="536" rx="8" fill="#1a1d2e"/>
+
+  <!-- Markdown Content -->
+  <!-- H1 -->
+  <text x="24" y="124" font-family="system-ui, sans-serif" font-size="20" font-weight="700" fill="#e2e8f0"># Welcome to MarkDrive</text>
+
+  <!-- Paragraph -->
+  <text x="24" y="156" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">A beautiful Markdown viewer</text>
+  <text x="24" y="172" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">for Google Drive files.</text>
+
+  <!-- H2 -->
+  <text x="24" y="210" font-family="system-ui, sans-serif" font-size="16" font-weight="600" fill="#e2e8f0">## Features</text>
+
+  <!-- List items -->
+  <circle cx="32" cy="240" r="3" fill="#6366f1"/>
+  <text x="44" y="244" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">Google Drive integration</text>
+
+  <circle cx="32" cy="266" r="3" fill="#6366f1"/>
+  <text x="44" y="270" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">Syntax highlighting</text>
+
+  <circle cx="32" cy="292" r="3" fill="#6366f1"/>
+  <text x="44" y="296" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">Mermaid diagram support</text>
+
+  <!-- Code Block -->
+  <rect x="24" y="316" width="272" height="72" rx="6" fill="#161b22"/>
+  <text x="36" y="338" font-family="monospace" font-size="11" fill="#8b949e">```javascript</text>
+  <text x="36" y="356" font-family="monospace" font-size="11" fill="#e6edf3">const viewer = new MDViewer();</text>
+  <text x="36" y="374" font-family="monospace" font-size="11" fill="#e6edf3">viewer.render(markdown);</text>
+
+  <!-- Table -->
+  <rect x="24" y="408" width="272" height="24" rx="4" fill="#111320"/>
+  <text x="36" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Feature</text>
+  <text x="180" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Status</text>
+  <line x1="24" y1="432" x2="296" y2="432" stroke="#1e2038" stroke-width="1"/>
+  <text x="36" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">GFM</text>
+  <text x="180" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#10b981">Ready</text>
+  <line x1="24" y1="460" x2="296" y2="460" stroke="#1e2038" stroke-width="1"/>
+  <text x="36" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">Mermaid</text>
+  <text x="180" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#10b981">Ready</text>
+  <line x1="24" y1="488" x2="296" y2="488" stroke="#1e2038" stroke-width="1"/>
+  <text x="36" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">KaTeX</text>
+  <text x="180" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#10b981">Ready</text>
+
+  <!-- Decorative gradient overlay -->
+  <defs>
+    <linearGradient id="fadeMobileDark" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0.75" stop-color="#0a0b14" stop-opacity="0"/>
+      <stop offset="1" stop-color="#0a0b14" stop-opacity="0.9"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="540" width="320" height="100" rx="36" fill="url(#fadeMobileDark)"/>
+
+  <!-- Home Indicator -->
+  <rect x="110" y="618" width="100" height="4" rx="2" fill="#64748b"/>
+</svg>

--- a/public/app-preview.svg
+++ b/public/app-preview.svg
@@ -1,10 +1,10 @@
-<svg width="800" height="500" viewBox="0 0 800 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Browser Frame -->
-  <rect x="0" y="0" width="800" height="500" rx="12" fill="#1a1f2e"/>
+  <rect x="0" y="0" width="500" height="500" rx="12" fill="#0a0b14"/>
 
   <!-- Title Bar -->
-  <rect x="0" y="0" width="800" height="40" rx="12" fill="#252b3b"/>
-  <rect x="0" y="28" width="800" height="12" fill="#252b3b"/>
+  <rect x="0" y="0" width="500" height="40" rx="12" fill="#111320"/>
+  <rect x="0" y="28" width="500" height="12" fill="#111320"/>
 
   <!-- Window Controls -->
   <circle cx="20" cy="20" r="6" fill="#ff5f57"/>
@@ -12,48 +12,49 @@
   <circle cx="60" cy="20" r="6" fill="#28c840"/>
 
   <!-- URL Bar -->
-  <rect x="100" y="10" width="600" height="20" rx="4" fill="#1a1f2e"/>
-  <text x="120" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">mark-drive.com</text>
+  <rect x="90" y="10" width="340" height="20" rx="4" fill="#0a0b14"/>
+  <text x="110" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">mark-drive.com</text>
 
   <!-- App Header -->
-  <rect x="20" y="56" width="760" height="48" rx="8" fill="#252b3b"/>
+  <rect x="20" y="56" width="460" height="48" rx="8" fill="#111320"/>
   <text x="40" y="86" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#e2e8f0">README.md</text>
 
   <!-- Content Area -->
-  <rect x="20" y="120" width="760" height="360" rx="8" fill="#1e2433"/>
+  <rect x="20" y="120" width="460" height="360" rx="8" fill="#1a1d2e"/>
 
   <!-- Markdown Content -->
   <!-- H1 -->
-  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#f1f5f9"># Welcome to MarkDrive</text>
+  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="22" font-weight="700" fill="#e2e8f0"># Welcome to MarkDrive</text>
 
   <!-- Paragraph -->
-  <text x="40" y="200" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">A beautiful Markdown viewer for Google Drive files.</text>
+  <text x="40" y="196" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">A beautiful Markdown viewer</text>
+  <text x="40" y="214" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">for Google Drive files.</text>
 
   <!-- H2 -->
-  <text x="40" y="250" font-family="system-ui, sans-serif" font-size="18" font-weight="600" fill="#e2e8f0">## Features</text>
+  <text x="40" y="254" font-family="system-ui, sans-serif" font-size="17" font-weight="600" fill="#e2e8f0">## Features</text>
 
   <!-- List items -->
   <circle cx="50" cy="285" r="3" fill="#6366f1"/>
-  <text x="65" y="290" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">Google Drive integration</text>
+  <text x="65" y="290" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Google Drive integration</text>
 
   <circle cx="50" cy="315" r="3" fill="#6366f1"/>
-  <text x="65" y="320" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">Beautiful syntax highlighting</text>
+  <text x="65" y="320" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Beautiful syntax highlighting</text>
 
   <circle cx="50" cy="345" r="3" fill="#6366f1"/>
-  <text x="65" y="350" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">Mermaid diagram support</text>
+  <text x="65" y="350" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Mermaid diagram support</text>
 
   <!-- Code Block -->
-  <rect x="40" y="375" width="720" height="80" rx="6" fill="#161b22"/>
-  <text x="55" y="400" font-family="monospace" font-size="12" fill="#7ee787">```javascript</text>
+  <rect x="40" y="375" width="420" height="80" rx="6" fill="#161b22"/>
+  <text x="55" y="400" font-family="monospace" font-size="12" fill="#8b949e">```javascript</text>
   <text x="55" y="420" font-family="monospace" font-size="12" fill="#e6edf3">const viewer = new MDViewer();</text>
   <text x="55" y="440" font-family="monospace" font-size="12" fill="#e6edf3">viewer.render(markdown);</text>
 
   <!-- Decorative gradient overlay -->
   <defs>
     <linearGradient id="fadeBottom" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0.7" stop-color="#1a1f2e" stop-opacity="0"/>
-      <stop offset="1" stop-color="#1a1f2e" stop-opacity="0.8"/>
+      <stop offset="0.7" stop-color="#0a0b14" stop-opacity="0"/>
+      <stop offset="1" stop-color="#0a0b14" stop-opacity="0.8"/>
     </linearGradient>
   </defs>
-  <rect x="0" y="400" width="800" height="100" fill="url(#fadeBottom)"/>
+  <rect x="0" y="400" width="500" height="100" fill="url(#fadeBottom)"/>
 </svg>


### PR DESCRIPTION
## Summary
- モバイル用スマホフレームSVG (320x640) を追加し、モバイルビューでも幅いっぱいでプレビュー画像を表示
- デスクトップ用SVGを 800x500 → 500x500 の正方形に変更
- 全4つのSVGプレビュー画像の配色を `colors.ts` / `lightColors.ts` のテーマカラーに統一
- SSR対応: `useWindowDimensions` → `useState(0)` + `useEffect` で hydration 後に正しい幅を取得

## 変更ファイル
- `app/index.tsx` - レスポンシブ対応、モバイル/デスクトップで異なるプレビュー画像切り替え
- `public/app-preview.svg` - 500x500、ダークテーマカラー統一
- `public/app-preview-light.svg` - 500x500、ライトテーマカラー統一
- `public/app-preview-mobile.svg` - 新規、320x640スマホフレーム (ダーク)
- `public/app-preview-mobile-light.svg` - 新規、320x640スマホフレーム (ライト)

## Test plan
- [ ] デスクトップ: 500x500の正方形プレビュー画像が表示される
- [ ] モバイル: スマホフレームのプレビュー画像が幅いっぱいで表示される
- [ ] ダーク/ライトテーマ切替で適切なSVGが表示される
- [ ] ダークモードでモバイルSVGのフレーム枠が見える
- [ ] 静的ビルド (`npx expo export -p web`) → `npx serve dist -s` で正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)