### PR TITLE
feat: ヒーロープレビュー画像の Raw/Rendered クロスフェードアニメーション

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -71,4 +71,12 @@ body {
   body {
     background-color: #0a0b14;
   }
+}
+@keyframes crossfade-raw {
+  0%   { opacity: 1; }
+  12%  { opacity: 1; }
+  25%  { opacity: 0; }
+  62%  { opacity: 0; }
+  75%  { opacity: 1; }
+  100% { opacity: 1; }
 }`;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -282,22 +282,55 @@ export default function HomeScreen() {
                 </Button>
               </View>
 
-              {/* Right: Preview image */}
+              {/* Right: Preview image with crossfade animation */}
               <View style={isDesktop ? styles.heroRight : styles.heroRightMobile}>
                 <View style={isDesktop ? [styles.previewContainer, { borderColor: colors.borderLight, ...shadows.md }] : styles.previewContainerMobile}>
                   {Platform.OS === 'web' && (
                     isDesktop ? (
-                      <img
-                        src={resolvedMode === 'dark' ? '/app-preview.svg' : '/app-preview-light.svg'}
-                        alt="MarkDrive Preview"
-                        style={{ width: '100%', height: 'auto', borderRadius: 8 }}
-                      />
+                      <div style={{ position: 'relative', width: '100%' }}>
+                        {/* Rendered preview (base layer) */}
+                        <img
+                          src={resolvedMode === 'dark' ? '/app-preview.svg' : '/app-preview-light.svg'}
+                          alt="MarkDrive Preview"
+                          style={{ width: '100%', height: 'auto', borderRadius: 8, display: 'block' }}
+                        />
+                        {/* Raw markdown (overlay with crossfade) */}
+                        <img
+                          src={resolvedMode === 'dark' ? '/app-preview-raw.svg' : '/app-preview-raw-light.svg'}
+                          alt="MarkDrive Raw Markdown"
+                          style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            width: '100%',
+                            height: 'auto',
+                            borderRadius: 8,
+                            animation: 'crossfade-raw 8s ease-in-out infinite',
+                          }}
+                        />
+                      </div>
                     ) : (
-                      <img
-                        src={resolvedMode === 'dark' ? '/app-preview-mobile.svg' : '/app-preview-mobile-light.svg'}
-                        alt="MarkDrive Mobile Preview"
-                        style={{ width: '100%', height: 'auto' }}
-                      />
+                      <div style={{ position: 'relative', width: '100%' }}>
+                        {/* Rendered preview (base layer) */}
+                        <img
+                          src={resolvedMode === 'dark' ? '/app-preview-mobile.svg' : '/app-preview-mobile-light.svg'}
+                          alt="MarkDrive Mobile Preview"
+                          style={{ width: '100%', height: 'auto', display: 'block' }}
+                        />
+                        {/* Raw markdown (overlay with crossfade) */}
+                        <img
+                          src={resolvedMode === 'dark' ? '/app-preview-mobile-raw.svg' : '/app-preview-mobile-raw-light.svg'}
+                          alt="MarkDrive Raw Markdown"
+                          style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            width: '100%',
+                            height: 'auto',
+                            animation: 'crossfade-raw 8s ease-in-out infinite',
+                          }}
+                        />
+                      </div>
                     )
                   )}
                 </View>

--- a/public/app-preview-light.svg
+++ b/public/app-preview-light.svg
@@ -23,32 +23,41 @@
   <!-- Content Area -->
   <rect x="20" y="120" width="460" height="360" rx="8" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
 
-  <!-- Markdown Content -->
-  <!-- H1 -->
-  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="22" font-weight="700" fill="#1a1b2e"># Welcome to MarkDrive</text>
+  <!-- Rendered Markdown Content -->
+  <!-- H1 (no # mark, rendered heading) -->
+  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#1a1b2e">Welcome to MarkDrive</text>
+  <!-- H1 bottom border -->
+  <line x1="40" y1="170" x2="440" y2="170" stroke="#e5e7eb" stroke-width="2"/>
 
   <!-- Paragraph -->
-  <text x="40" y="196" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">A beautiful Markdown viewer</text>
-  <text x="40" y="214" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">for Google Drive files.</text>
+  <text x="40" y="200" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">A beautiful Markdown viewer</text>
+  <text x="40" y="220" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">for Google Drive files.</text>
 
-  <!-- H2 -->
-  <text x="40" y="254" font-family="system-ui, sans-serif" font-size="17" font-weight="600" fill="#1a1b2e">## Features</text>
+  <!-- H2 (no ## mark, rendered heading) -->
+  <text x="40" y="260" font-family="system-ui, sans-serif" font-size="19" font-weight="600" fill="#1a1b2e">Features</text>
+  <!-- H2 bottom border -->
+  <line x1="40" y1="268" x2="440" y2="268" stroke="#e5e7eb" stroke-width="1"/>
 
-  <!-- List items -->
-  <circle cx="50" cy="285" r="3" fill="#6366f1"/>
-  <text x="65" y="290" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Google Drive integration</text>
+  <!-- List items with disc bullets -->
+  <circle cx="50" cy="295" r="3" fill="#1a1b2e"/>
+  <text x="62" y="300" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">Google Drive integration</text>
 
-  <circle cx="50" cy="315" r="3" fill="#6366f1"/>
-  <text x="65" y="320" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Beautiful syntax highlighting</text>
+  <circle cx="50" cy="323" r="3" fill="#1a1b2e"/>
+  <text x="62" y="328" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">Beautiful syntax highlighting</text>
 
-  <circle cx="50" cy="345" r="3" fill="#6366f1"/>
-  <text x="65" y="350" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Mermaid diagram support</text>
+  <circle cx="50" cy="351" r="3" fill="#1a1b2e"/>
+  <text x="62" y="356" font-family="system-ui, sans-serif" font-size="14" fill="#4b5563">Mermaid diagram support</text>
 
-  <!-- Code Block -->
-  <rect x="40" y="375" width="420" height="80" rx="6" fill="#f6f8fa"/>
-  <text x="55" y="400" font-family="monospace" font-size="12" fill="#6e7781">```javascript</text>
-  <text x="55" y="420" font-family="monospace" font-size="12" fill="#24292f">const viewer = new MDViewer();</text>
-  <text x="55" y="440" font-family="monospace" font-size="12" fill="#24292f">viewer.render(markdown);</text>
+  <!-- Code Block with language label -->
+  <rect x="40" y="376" width="420" height="90" rx="6" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1"/>
+  <!-- Language label bar -->
+  <rect x="40" y="376" width="420" height="22" rx="6" fill="#f6f8fa"/>
+  <rect x="40" y="392" width="420" height="6" fill="#f6f8fa"/>
+  <line x1="40" y1="398" x2="460" y2="398" stroke="#d0d7de" stroke-width="1"/>
+  <text x="52" y="392" font-family="monospace" font-size="11" fill="#6e7781">javascript</text>
+  <!-- Code content with syntax highlighting -->
+  <text x="52" y="418" font-family="monospace" font-size="12"><tspan fill="#cf222e">const</tspan><tspan fill="#24292f"> viewer = </tspan><tspan fill="#cf222e">new</tspan><tspan fill="#24292f"> </tspan><tspan fill="#8250df">MDViewer</tspan><tspan fill="#24292f">();</tspan></text>
+  <text x="52" y="438" font-family="monospace" font-size="12"><tspan fill="#24292f">viewer.</tspan><tspan fill="#8250df">render</tspan><tspan fill="#24292f">(markdown);</tspan></text>
 
   <!-- Decorative gradient overlay -->
   <defs>

--- a/public/app-preview-mobile-light.svg
+++ b/public/app-preview-mobile-light.svg
@@ -15,46 +15,51 @@
   <!-- Content Area -->
   <rect x="12" y="92" width="296" height="536" rx="8" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
 
-  <!-- Markdown Content -->
+  <!-- Rendered Markdown Content -->
   <!-- H1 -->
-  <text x="24" y="124" font-family="system-ui, sans-serif" font-size="20" font-weight="700" fill="#1a1b2e"># Welcome to MarkDrive</text>
+  <text x="24" y="126" font-family="system-ui, sans-serif" font-size="22" font-weight="700" fill="#1a1b2e">Welcome to MarkDrive</text>
+  <line x1="24" y1="134" x2="296" y2="134" stroke="#e5e7eb" stroke-width="2"/>
 
   <!-- Paragraph -->
-  <text x="24" y="156" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">A beautiful Markdown viewer</text>
-  <text x="24" y="172" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">for Google Drive files.</text>
+  <text x="24" y="162" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">A beautiful Markdown viewer</text>
+  <text x="24" y="180" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">for Google Drive files.</text>
 
   <!-- H2 -->
-  <text x="24" y="210" font-family="system-ui, sans-serif" font-size="16" font-weight="600" fill="#1a1b2e">## Features</text>
+  <text x="24" y="218" font-family="system-ui, sans-serif" font-size="17" font-weight="600" fill="#1a1b2e">Features</text>
+  <line x1="24" y1="226" x2="296" y2="226" stroke="#e5e7eb" stroke-width="1"/>
 
   <!-- List items -->
-  <circle cx="32" cy="240" r="3" fill="#6366f1"/>
-  <text x="44" y="244" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">Google Drive integration</text>
+  <circle cx="32" cy="250" r="3" fill="#1a1b2e"/>
+  <text x="44" y="254" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Google Drive integration</text>
 
-  <circle cx="32" cy="266" r="3" fill="#6366f1"/>
-  <text x="44" y="270" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">Syntax highlighting</text>
+  <circle cx="32" cy="278" r="3" fill="#1a1b2e"/>
+  <text x="44" y="282" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Syntax highlighting</text>
 
-  <circle cx="32" cy="292" r="3" fill="#6366f1"/>
-  <text x="44" y="296" font-family="system-ui, sans-serif" font-size="12" fill="#4b5563">Mermaid diagram support</text>
+  <circle cx="32" cy="306" r="3" fill="#1a1b2e"/>
+  <text x="44" y="310" font-family="system-ui, sans-serif" font-size="13" fill="#4b5563">Mermaid diagram support</text>
 
-  <!-- Code Block -->
-  <rect x="24" y="316" width="272" height="72" rx="6" fill="#f6f8fa"/>
-  <text x="36" y="338" font-family="monospace" font-size="11" fill="#6e7781">```javascript</text>
-  <text x="36" y="356" font-family="monospace" font-size="11" fill="#24292f">const viewer = new MDViewer();</text>
-  <text x="36" y="374" font-family="monospace" font-size="11" fill="#24292f">viewer.render(markdown);</text>
+  <!-- Code Block with language label -->
+  <rect x="24" y="332" width="272" height="80" rx="6" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1"/>
+  <rect x="24" y="332" width="272" height="20" rx="6" fill="#f6f8fa"/>
+  <rect x="24" y="346" width="272" height="6" fill="#f6f8fa"/>
+  <line x1="24" y1="352" x2="296" y2="352" stroke="#d0d7de" stroke-width="1"/>
+  <text x="34" y="347" font-family="monospace" font-size="10" fill="#6e7781">javascript</text>
+  <text x="34" y="370" font-family="monospace" font-size="11"><tspan fill="#cf222e">const</tspan><tspan fill="#24292f"> viewer = </tspan><tspan fill="#cf222e">new</tspan><tspan fill="#24292f"> </tspan><tspan fill="#8250df">MDViewer</tspan><tspan fill="#24292f">();</tspan></text>
+  <text x="34" y="388" font-family="monospace" font-size="11"><tspan fill="#24292f">viewer.</tspan><tspan fill="#8250df">render</tspan><tspan fill="#24292f">(markdown);</tspan></text>
 
   <!-- Table -->
-  <rect x="24" y="408" width="272" height="24" rx="4" fill="#f0f0f8"/>
-  <text x="36" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1a1b2e">Feature</text>
-  <text x="180" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1a1b2e">Status</text>
-  <line x1="24" y1="432" x2="296" y2="432" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="36" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">GFM</text>
-  <text x="180" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#059669">Ready</text>
-  <line x1="24" y1="460" x2="296" y2="460" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="36" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">Mermaid</text>
-  <text x="180" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#059669">Ready</text>
-  <line x1="24" y1="488" x2="296" y2="488" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="36" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">KaTeX</text>
-  <text x="180" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#059669">Ready</text>
+  <rect x="24" y="430" width="272" height="24" rx="4" fill="#f0f0f8"/>
+  <text x="36" y="446" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1a1b2e">Feature</text>
+  <text x="180" y="446" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#1a1b2e">Status</text>
+  <line x1="24" y1="454" x2="296" y2="454" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="36" y="474" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">GFM</text>
+  <text x="180" y="474" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">Ready</text>
+  <line x1="24" y1="482" x2="296" y2="482" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="36" y="502" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">Mermaid</text>
+  <text x="180" y="502" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">Ready</text>
+  <line x1="24" y1="510" x2="296" y2="510" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="36" y="530" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">KaTeX</text>
+  <text x="180" y="530" font-family="system-ui, sans-serif" font-size="11" fill="#4b5563">Ready</text>
 
   <!-- Decorative gradient overlay -->
   <defs>
@@ -64,6 +69,9 @@
     </linearGradient>
   </defs>
   <rect x="0" y="540" width="320" height="100" rx="36" fill="url(#fadeMobileLight)"/>
+
+  <!-- Phone Frame border (re-draw on top of gradient) -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="none" stroke="#e5e7eb" stroke-width="2"/>
 
   <!-- Home Indicator -->
   <rect x="110" y="618" width="100" height="4" rx="2" fill="#d1d5db"/>

--- a/public/app-preview-mobile-raw-light.svg
+++ b/public/app-preview-mobile-raw-light.svg
@@ -1,0 +1,50 @@
+<svg width="320" height="640" viewBox="0 0 320 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Phone Frame -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="#ffffff" stroke="#e5e7eb" stroke-width="2"/>
+
+  <!-- Status Bar -->
+  <text x="24" y="24" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#1a1b2e">9:41</text>
+  <circle cx="280" cy="19" r="4" fill="#1a1b2e"/>
+  <rect x="254" y="16" width="16" height="7" rx="2" fill="#1a1b2e"/>
+  <rect x="236" y="14" width="12" height="10" rx="1" fill="none" stroke="#1a1b2e" stroke-width="1.5"/>
+
+  <!-- App Header -->
+  <rect x="12" y="40" width="296" height="40" rx="8" fill="#f8f8fd"/>
+  <text x="28" y="65" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1a1b2e">README.md</text>
+
+  <!-- Content Area -->
+  <rect x="12" y="92" width="296" height="536" rx="8" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+
+  <!-- Raw Markdown Source (monospace, plain text) -->
+  <text x="24" y="118" font-family="monospace" font-size="11" fill="#7c3aed"># Welcome to MarkDrive</text>
+  <text x="24" y="140" font-family="monospace" font-size="11" fill="#374151">A beautiful Markdown viewer</text>
+  <text x="24" y="158" font-family="monospace" font-size="11" fill="#374151">for Google Drive files.</text>
+  <text x="24" y="184" font-family="monospace" font-size="11" fill="#7c3aed">## Features</text>
+  <text x="24" y="210" font-family="monospace" font-size="11" fill="#374151">- Google Drive integration</text>
+  <text x="24" y="228" font-family="monospace" font-size="11" fill="#374151">- Syntax highlighting</text>
+  <text x="24" y="246" font-family="monospace" font-size="11" fill="#374151">- Mermaid diagram support</text>
+  <text x="24" y="272" font-family="monospace" font-size="11" fill="#059669">```javascript</text>
+  <text x="24" y="290" font-family="monospace" font-size="11" fill="#374151">const viewer = new MDViewer();</text>
+  <text x="24" y="308" font-family="monospace" font-size="11" fill="#374151">viewer.render(markdown);</text>
+  <text x="24" y="326" font-family="monospace" font-size="11" fill="#059669">```</text>
+  <text x="24" y="356" font-family="monospace" font-size="11" fill="#374151">| Feature | Status |</text>
+  <text x="24" y="374" font-family="monospace" font-size="11" fill="#374151">|---------|--------|</text>
+  <text x="24" y="392" font-family="monospace" font-size="11" fill="#374151">| GFM     | Ready  |</text>
+  <text x="24" y="410" font-family="monospace" font-size="11" fill="#374151">| Mermaid | Ready  |</text>
+  <text x="24" y="428" font-family="monospace" font-size="11" fill="#374151">| KaTeX   | Ready  |</text>
+
+  <!-- Decorative gradient overlay -->
+  <defs>
+    <linearGradient id="fadeMobileRawLight" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0.75" stop-color="#ffffff" stop-opacity="0"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0.9"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="540" width="320" height="100" rx="36" fill="url(#fadeMobileRawLight)"/>
+
+  <!-- Phone Frame border (re-draw on top of gradient) -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="none" stroke="#e5e7eb" stroke-width="2"/>
+
+  <!-- Home Indicator -->
+  <rect x="110" y="618" width="100" height="4" rx="2" fill="#d1d5db"/>
+</svg>

--- a/public/app-preview-mobile-raw.svg
+++ b/public/app-preview-mobile-raw.svg
@@ -1,0 +1,50 @@
+<svg width="320" height="640" viewBox="0 0 320 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Phone Frame -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="#0a0b14" stroke="#1e2038" stroke-width="2"/>
+
+  <!-- Status Bar -->
+  <text x="24" y="24" font-family="system-ui, sans-serif" font-size="12" font-weight="600" fill="#e2e8f0">9:41</text>
+  <circle cx="280" cy="19" r="4" fill="#e2e8f0"/>
+  <rect x="254" y="16" width="16" height="7" rx="2" fill="#e2e8f0"/>
+  <rect x="236" y="14" width="12" height="10" rx="1" fill="none" stroke="#e2e8f0" stroke-width="1.5"/>
+
+  <!-- App Header -->
+  <rect x="12" y="40" width="296" height="40" rx="8" fill="#111320"/>
+  <text x="28" y="65" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#e2e8f0">README.md</text>
+
+  <!-- Content Area -->
+  <rect x="12" y="92" width="296" height="536" rx="8" fill="#1a1d2e"/>
+
+  <!-- Raw Markdown Source (monospace, plain text) -->
+  <text x="24" y="118" font-family="monospace" font-size="11" fill="#c084fc"># Welcome to MarkDrive</text>
+  <text x="24" y="140" font-family="monospace" font-size="11" fill="#cbd5e1">A beautiful Markdown viewer</text>
+  <text x="24" y="158" font-family="monospace" font-size="11" fill="#cbd5e1">for Google Drive files.</text>
+  <text x="24" y="184" font-family="monospace" font-size="11" fill="#c084fc">## Features</text>
+  <text x="24" y="210" font-family="monospace" font-size="11" fill="#cbd5e1">- Google Drive integration</text>
+  <text x="24" y="228" font-family="monospace" font-size="11" fill="#cbd5e1">- Syntax highlighting</text>
+  <text x="24" y="246" font-family="monospace" font-size="11" fill="#cbd5e1">- Mermaid diagram support</text>
+  <text x="24" y="272" font-family="monospace" font-size="11" fill="#6ee7b7">```javascript</text>
+  <text x="24" y="290" font-family="monospace" font-size="11" fill="#cbd5e1">const viewer = new MDViewer();</text>
+  <text x="24" y="308" font-family="monospace" font-size="11" fill="#cbd5e1">viewer.render(markdown);</text>
+  <text x="24" y="326" font-family="monospace" font-size="11" fill="#6ee7b7">```</text>
+  <text x="24" y="356" font-family="monospace" font-size="11" fill="#cbd5e1">| Feature | Status |</text>
+  <text x="24" y="374" font-family="monospace" font-size="11" fill="#cbd5e1">|---------|--------|</text>
+  <text x="24" y="392" font-family="monospace" font-size="11" fill="#cbd5e1">| GFM     | Ready  |</text>
+  <text x="24" y="410" font-family="monospace" font-size="11" fill="#cbd5e1">| Mermaid | Ready  |</text>
+  <text x="24" y="428" font-family="monospace" font-size="11" fill="#cbd5e1">| KaTeX   | Ready  |</text>
+
+  <!-- Decorative gradient overlay -->
+  <defs>
+    <linearGradient id="fadeMobileRawDark" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0.75" stop-color="#0a0b14" stop-opacity="0"/>
+      <stop offset="1" stop-color="#0a0b14" stop-opacity="0.9"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="540" width="320" height="100" rx="36" fill="url(#fadeMobileRawDark)"/>
+
+  <!-- Phone Frame border (re-draw on top of gradient) -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="none" stroke="#1e2038" stroke-width="2"/>
+
+  <!-- Home Indicator -->
+  <rect x="110" y="618" width="100" height="4" rx="2" fill="#64748b"/>
+</svg>

--- a/public/app-preview-mobile.svg
+++ b/public/app-preview-mobile.svg
@@ -15,46 +15,51 @@
   <!-- Content Area -->
   <rect x="12" y="92" width="296" height="536" rx="8" fill="#1a1d2e"/>
 
-  <!-- Markdown Content -->
+  <!-- Rendered Markdown Content -->
   <!-- H1 -->
-  <text x="24" y="124" font-family="system-ui, sans-serif" font-size="20" font-weight="700" fill="#e2e8f0"># Welcome to MarkDrive</text>
+  <text x="24" y="126" font-family="system-ui, sans-serif" font-size="22" font-weight="700" fill="#e2e8f0">Welcome to MarkDrive</text>
+  <line x1="24" y1="134" x2="296" y2="134" stroke="#1e2038" stroke-width="2"/>
 
   <!-- Paragraph -->
-  <text x="24" y="156" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">A beautiful Markdown viewer</text>
-  <text x="24" y="172" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">for Google Drive files.</text>
+  <text x="24" y="162" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">A beautiful Markdown viewer</text>
+  <text x="24" y="180" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">for Google Drive files.</text>
 
   <!-- H2 -->
-  <text x="24" y="210" font-family="system-ui, sans-serif" font-size="16" font-weight="600" fill="#e2e8f0">## Features</text>
+  <text x="24" y="218" font-family="system-ui, sans-serif" font-size="17" font-weight="600" fill="#e2e8f0">Features</text>
+  <line x1="24" y1="226" x2="296" y2="226" stroke="#1e2038" stroke-width="1"/>
 
   <!-- List items -->
-  <circle cx="32" cy="240" r="3" fill="#6366f1"/>
-  <text x="44" y="244" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">Google Drive integration</text>
+  <circle cx="32" cy="250" r="3" fill="#e2e8f0"/>
+  <text x="44" y="254" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Google Drive integration</text>
 
-  <circle cx="32" cy="266" r="3" fill="#6366f1"/>
-  <text x="44" y="270" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">Syntax highlighting</text>
+  <circle cx="32" cy="278" r="3" fill="#e2e8f0"/>
+  <text x="44" y="282" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Syntax highlighting</text>
 
-  <circle cx="32" cy="292" r="3" fill="#6366f1"/>
-  <text x="44" y="296" font-family="system-ui, sans-serif" font-size="12" fill="#94a3b8">Mermaid diagram support</text>
+  <circle cx="32" cy="306" r="3" fill="#e2e8f0"/>
+  <text x="44" y="310" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Mermaid diagram support</text>
 
-  <!-- Code Block -->
-  <rect x="24" y="316" width="272" height="72" rx="6" fill="#161b22"/>
-  <text x="36" y="338" font-family="monospace" font-size="11" fill="#8b949e">```javascript</text>
-  <text x="36" y="356" font-family="monospace" font-size="11" fill="#e6edf3">const viewer = new MDViewer();</text>
-  <text x="36" y="374" font-family="monospace" font-size="11" fill="#e6edf3">viewer.render(markdown);</text>
+  <!-- Code Block with language label -->
+  <rect x="24" y="332" width="272" height="80" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <rect x="24" y="332" width="272" height="20" rx="6" fill="#161b22"/>
+  <rect x="24" y="346" width="272" height="6" fill="#161b22"/>
+  <line x1="24" y1="352" x2="296" y2="352" stroke="#30363d" stroke-width="1"/>
+  <text x="34" y="347" font-family="monospace" font-size="10" fill="#8b949e">javascript</text>
+  <text x="34" y="370" font-family="monospace" font-size="11"><tspan fill="#ff7b72">const</tspan><tspan fill="#e6edf3"> viewer = </tspan><tspan fill="#ff7b72">new</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#d2a8ff">MDViewer</tspan><tspan fill="#e6edf3">();</tspan></text>
+  <text x="34" y="388" font-family="monospace" font-size="11"><tspan fill="#e6edf3">viewer.</tspan><tspan fill="#d2a8ff">render</tspan><tspan fill="#e6edf3">(markdown);</tspan></text>
 
   <!-- Table -->
-  <rect x="24" y="408" width="272" height="24" rx="4" fill="#111320"/>
-  <text x="36" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Feature</text>
-  <text x="180" y="424" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Status</text>
-  <line x1="24" y1="432" x2="296" y2="432" stroke="#1e2038" stroke-width="1"/>
-  <text x="36" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">GFM</text>
-  <text x="180" y="452" font-family="system-ui, sans-serif" font-size="11" fill="#10b981">Ready</text>
-  <line x1="24" y1="460" x2="296" y2="460" stroke="#1e2038" stroke-width="1"/>
-  <text x="36" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">Mermaid</text>
-  <text x="180" y="480" font-family="system-ui, sans-serif" font-size="11" fill="#10b981">Ready</text>
-  <line x1="24" y1="488" x2="296" y2="488" stroke="#1e2038" stroke-width="1"/>
-  <text x="36" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">KaTeX</text>
-  <text x="180" y="508" font-family="system-ui, sans-serif" font-size="11" fill="#10b981">Ready</text>
+  <rect x="24" y="430" width="272" height="24" rx="4" fill="#111320"/>
+  <text x="36" y="446" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Feature</text>
+  <text x="180" y="446" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#e2e8f0">Status</text>
+  <line x1="24" y1="454" x2="296" y2="454" stroke="#1e2038" stroke-width="1"/>
+  <text x="36" y="474" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">GFM</text>
+  <text x="180" y="474" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">Ready</text>
+  <line x1="24" y1="482" x2="296" y2="482" stroke="#1e2038" stroke-width="1"/>
+  <text x="36" y="502" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">Mermaid</text>
+  <text x="180" y="502" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">Ready</text>
+  <line x1="24" y1="510" x2="296" y2="510" stroke="#1e2038" stroke-width="1"/>
+  <text x="36" y="530" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">KaTeX</text>
+  <text x="180" y="530" font-family="system-ui, sans-serif" font-size="11" fill="#94a3b8">Ready</text>
 
   <!-- Decorative gradient overlay -->
   <defs>
@@ -64,6 +69,9 @@
     </linearGradient>
   </defs>
   <rect x="0" y="540" width="320" height="100" rx="36" fill="url(#fadeMobileDark)"/>
+
+  <!-- Phone Frame border (re-draw on top of gradient) -->
+  <rect x="0" y="0" width="320" height="640" rx="36" fill="none" stroke="#1e2038" stroke-width="2"/>
 
   <!-- Home Indicator -->
   <rect x="110" y="618" width="100" height="4" rx="2" fill="#64748b"/>

--- a/public/app-preview-raw-light.svg
+++ b/public/app-preview-raw-light.svg
@@ -1,0 +1,47 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Browser Frame -->
+  <rect x="0" y="0" width="500" height="500" rx="12" fill="#ffffff"/>
+  <rect x="0" y="0" width="500" height="500" rx="12" stroke="#e5e7eb" stroke-width="1"/>
+
+  <!-- Title Bar -->
+  <rect x="0" y="0" width="500" height="40" rx="12" fill="#f8f8fd"/>
+  <rect x="0" y="28" width="500" height="12" fill="#f8f8fd"/>
+
+  <!-- Window Controls -->
+  <circle cx="20" cy="20" r="6" fill="#ff5f57"/>
+  <circle cx="40" cy="20" r="6" fill="#febc2e"/>
+  <circle cx="60" cy="20" r="6" fill="#28c840"/>
+
+  <!-- URL Bar -->
+  <rect x="90" y="10" width="340" height="20" rx="4" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="110" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#6b7280">mark-drive.com</text>
+
+  <!-- App Header -->
+  <rect x="20" y="56" width="460" height="48" rx="8" fill="#f8f8fd"/>
+  <text x="40" y="86" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#1a1b2e">README.md</text>
+
+  <!-- Content Area -->
+  <rect x="20" y="120" width="460" height="360" rx="8" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+
+  <!-- Raw Markdown Source (monospace, plain text) -->
+  <text x="40" y="148" font-family="monospace" font-size="12" fill="#7c3aed"># Welcome to MarkDrive</text>
+  <text x="40" y="172" font-family="monospace" font-size="12" fill="#374151">A beautiful Markdown viewer</text>
+  <text x="40" y="192" font-family="monospace" font-size="12" fill="#374151">for Google Drive files.</text>
+  <text x="40" y="220" font-family="monospace" font-size="12" fill="#7c3aed">## Features</text>
+  <text x="40" y="248" font-family="monospace" font-size="12" fill="#374151">- Google Drive integration</text>
+  <text x="40" y="268" font-family="monospace" font-size="12" fill="#374151">- Beautiful syntax highlighting</text>
+  <text x="40" y="288" font-family="monospace" font-size="12" fill="#374151">- Mermaid diagram support</text>
+  <text x="40" y="316" font-family="monospace" font-size="12" fill="#059669">```javascript</text>
+  <text x="40" y="336" font-family="monospace" font-size="12" fill="#374151">const viewer = new MDViewer();</text>
+  <text x="40" y="356" font-family="monospace" font-size="12" fill="#374151">viewer.render(markdown);</text>
+  <text x="40" y="376" font-family="monospace" font-size="12" fill="#059669">```</text>
+
+  <!-- Decorative gradient overlay -->
+  <defs>
+    <linearGradient id="fadeBottomRawLight" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0.7" stop-color="#ffffff" stop-opacity="0"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0.8"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="400" width="500" height="100" fill="url(#fadeBottomRawLight)"/>
+</svg>

--- a/public/app-preview-raw.svg
+++ b/public/app-preview-raw.svg
@@ -1,0 +1,46 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Browser Frame -->
+  <rect x="0" y="0" width="500" height="500" rx="12" fill="#0a0b14"/>
+
+  <!-- Title Bar -->
+  <rect x="0" y="0" width="500" height="40" rx="12" fill="#111320"/>
+  <rect x="0" y="28" width="500" height="12" fill="#111320"/>
+
+  <!-- Window Controls -->
+  <circle cx="20" cy="20" r="6" fill="#ff5f57"/>
+  <circle cx="40" cy="20" r="6" fill="#febc2e"/>
+  <circle cx="60" cy="20" r="6" fill="#28c840"/>
+
+  <!-- URL Bar -->
+  <rect x="90" y="10" width="340" height="20" rx="4" fill="#0a0b14"/>
+  <text x="110" y="24" font-family="system-ui, sans-serif" font-size="11" fill="#64748b">mark-drive.com</text>
+
+  <!-- App Header -->
+  <rect x="20" y="56" width="460" height="48" rx="8" fill="#111320"/>
+  <text x="40" y="86" font-family="system-ui, sans-serif" font-size="14" font-weight="600" fill="#e2e8f0">README.md</text>
+
+  <!-- Content Area -->
+  <rect x="20" y="120" width="460" height="360" rx="8" fill="#1a1d2e"/>
+
+  <!-- Raw Markdown Source (monospace, plain text) -->
+  <text x="40" y="148" font-family="monospace" font-size="12" fill="#c084fc"># Welcome to MarkDrive</text>
+  <text x="40" y="172" font-family="monospace" font-size="12" fill="#cbd5e1">A beautiful Markdown viewer</text>
+  <text x="40" y="192" font-family="monospace" font-size="12" fill="#cbd5e1">for Google Drive files.</text>
+  <text x="40" y="220" font-family="monospace" font-size="12" fill="#c084fc">## Features</text>
+  <text x="40" y="248" font-family="monospace" font-size="12" fill="#cbd5e1">- Google Drive integration</text>
+  <text x="40" y="268" font-family="monospace" font-size="12" fill="#cbd5e1">- Beautiful syntax highlighting</text>
+  <text x="40" y="288" font-family="monospace" font-size="12" fill="#cbd5e1">- Mermaid diagram support</text>
+  <text x="40" y="316" font-family="monospace" font-size="12" fill="#6ee7b7">```javascript</text>
+  <text x="40" y="336" font-family="monospace" font-size="12" fill="#cbd5e1">const viewer = new MDViewer();</text>
+  <text x="40" y="356" font-family="monospace" font-size="12" fill="#cbd5e1">viewer.render(markdown);</text>
+  <text x="40" y="376" font-family="monospace" font-size="12" fill="#6ee7b7">```</text>
+
+  <!-- Decorative gradient overlay -->
+  <defs>
+    <linearGradient id="fadeBottomRaw" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0.7" stop-color="#0a0b14" stop-opacity="0"/>
+      <stop offset="1" stop-color="#0a0b14" stop-opacity="0.8"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="400" width="500" height="100" fill="url(#fadeBottomRaw)"/>
+</svg>

--- a/public/app-preview.svg
+++ b/public/app-preview.svg
@@ -22,32 +22,41 @@
   <!-- Content Area -->
   <rect x="20" y="120" width="460" height="360" rx="8" fill="#1a1d2e"/>
 
-  <!-- Markdown Content -->
-  <!-- H1 -->
-  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="22" font-weight="700" fill="#e2e8f0"># Welcome to MarkDrive</text>
+  <!-- Rendered Markdown Content -->
+  <!-- H1 (no # mark, rendered heading) -->
+  <text x="40" y="160" font-family="system-ui, sans-serif" font-size="24" font-weight="700" fill="#e2e8f0">Welcome to MarkDrive</text>
+  <!-- H1 bottom border -->
+  <line x1="40" y1="170" x2="440" y2="170" stroke="#1e2038" stroke-width="2"/>
 
   <!-- Paragraph -->
-  <text x="40" y="196" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">A beautiful Markdown viewer</text>
-  <text x="40" y="214" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">for Google Drive files.</text>
+  <text x="40" y="200" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">A beautiful Markdown viewer</text>
+  <text x="40" y="220" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">for Google Drive files.</text>
 
-  <!-- H2 -->
-  <text x="40" y="254" font-family="system-ui, sans-serif" font-size="17" font-weight="600" fill="#e2e8f0">## Features</text>
+  <!-- H2 (no ## mark, rendered heading) -->
+  <text x="40" y="260" font-family="system-ui, sans-serif" font-size="19" font-weight="600" fill="#e2e8f0">Features</text>
+  <!-- H2 bottom border -->
+  <line x1="40" y1="268" x2="440" y2="268" stroke="#1e2038" stroke-width="1"/>
 
-  <!-- List items -->
-  <circle cx="50" cy="285" r="3" fill="#6366f1"/>
-  <text x="65" y="290" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Google Drive integration</text>
+  <!-- List items with disc bullets -->
+  <circle cx="50" cy="295" r="3" fill="#e2e8f0"/>
+  <text x="62" y="300" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">Google Drive integration</text>
 
-  <circle cx="50" cy="315" r="3" fill="#6366f1"/>
-  <text x="65" y="320" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Beautiful syntax highlighting</text>
+  <circle cx="50" cy="323" r="3" fill="#e2e8f0"/>
+  <text x="62" y="328" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">Beautiful syntax highlighting</text>
 
-  <circle cx="50" cy="345" r="3" fill="#6366f1"/>
-  <text x="65" y="350" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Mermaid diagram support</text>
+  <circle cx="50" cy="351" r="3" fill="#e2e8f0"/>
+  <text x="62" y="356" font-family="system-ui, sans-serif" font-size="14" fill="#94a3b8">Mermaid diagram support</text>
 
-  <!-- Code Block -->
-  <rect x="40" y="375" width="420" height="80" rx="6" fill="#161b22"/>
-  <text x="55" y="400" font-family="monospace" font-size="12" fill="#8b949e">```javascript</text>
-  <text x="55" y="420" font-family="monospace" font-size="12" fill="#e6edf3">const viewer = new MDViewer();</text>
-  <text x="55" y="440" font-family="monospace" font-size="12" fill="#e6edf3">viewer.render(markdown);</text>
+  <!-- Code Block with language label -->
+  <rect x="40" y="376" width="420" height="90" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <!-- Language label bar -->
+  <rect x="40" y="376" width="420" height="22" rx="6" fill="#161b22"/>
+  <rect x="40" y="392" width="420" height="6" fill="#161b22"/>
+  <line x1="40" y1="398" x2="460" y2="398" stroke="#30363d" stroke-width="1"/>
+  <text x="52" y="392" font-family="monospace" font-size="11" fill="#8b949e">javascript</text>
+  <!-- Code content with syntax highlighting -->
+  <text x="52" y="418" font-family="monospace" font-size="12"><tspan fill="#ff7b72">const</tspan><tspan fill="#e6edf3"> viewer = </tspan><tspan fill="#ff7b72">new</tspan><tspan fill="#e6edf3"> </tspan><tspan fill="#d2a8ff">MDViewer</tspan><tspan fill="#e6edf3">();</tspan></text>
+  <text x="52" y="438" font-family="monospace" font-size="12"><tspan fill="#e6edf3">viewer.</tspan><tspan fill="#d2a8ff">render</tspan><tspan fill="#e6edf3">(markdown);</tspan></text>
 
   <!-- Decorative gradient overlay -->
   <defs>


### PR DESCRIPTION
## Summary

- ヒーローセクションのプレビュー画像を、Raw Markdown ソースと Rendered プレビューの2枚でクロスフェードするアニメーションを実装
- 「Markdown を美しく表示する」というアプリの価値を直感的に伝える演出
- Rendered SVG を実際のアプリ表示に合わせて修正（見出し下線、シンタックスハイライト、テーブル色等）

### 変更内容

| ファイル | 変更 |
|---------|------|
| `public/app-preview-raw.svg` | **新規** raw markdown (desktop dark) |
| `public/app-preview-raw-light.svg` | **新規** raw markdown (desktop light) |
| `public/app-preview-mobile-raw.svg` | **新規** raw markdown (mobile dark) |
| `public/app-preview-mobile-raw-light.svg` | **新規** raw markdown (mobile light) |
| `public/app-preview*.svg` (既存4ファイル) | Rendered SVG を実際の表示に合わせて修正 |
| `app/+html.tsx` | `@keyframes crossfade-raw` CSS 追加 |
| `app/index.tsx` | ヒーロー画像を2枚重ね + CSS animation 適用 |

### アニメーション仕様
- 8秒サイクルでループ
- Raw Markdown → (1s フェード) → Rendered → (3s 表示) → (1s フェード) → Raw → 繰り返し

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npm run build` ビルド成功
- [ ] デスクトップ表示でクロスフェード動作確認
- [ ] モバイル表示でクロスフェード動作確認
- [ ] ダーク/ライトテーマ切替で適切な SVG が使われるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)