### PR TITLE
feat: 編集保存をローカルに変更 + ローカルファイル上書き保存対応

### DIFF
--- a/app/viewer.tsx
+++ b/app/viewer.tsx
@@ -21,7 +21,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { spacing, borderRadius, fontSize, fontWeight } from '../src/theme';
 import { Button } from '../src/components/ui';
 import { MarkdownRenderer } from '../src/components/markdown';
-import { useGoogleAuth, useShare, useTheme, useLanguage, useMarkdownEditor } from '../src/hooks';
+import { useGoogleAuth, useShare, useTheme, useLanguage, useMarkdownEditor, getFileHandle } from '../src/hooks';
 import { useFontSettings, FontSize, FontFamily } from '../src/contexts/FontSettingsContext';
 import { CodeMirrorEditor } from '../src/components/editor/CodeMirrorEditor';
 import { addFileToHistory } from '../src/services';
@@ -43,11 +43,12 @@ export default function ViewerScreen() {
 
   const [content, setContent] = useState<string | null>(params.content || null);
 
+  const fileHandle = useMemo(() => getFileHandle(params.id), [params.id]);
+
   const editor = useMarkdownEditor({
     initialContent: content,
-    fileId: params.id,
-    source: params.source as 'google-drive' | 'local',
-    accessToken,
+    fileName: params.name,
+    fileHandle,
     onContentSaved: (newContent) => setContent(newContent),
   });
   const [isLoading, setIsLoading] = useState(!params.content);
@@ -475,17 +476,15 @@ export default function ViewerScreen() {
                     </Text>
                   </>
                 )}
-                {(editor.saveError || editor.needsReauth) && !editor.isSaving && (
+                {editor.saveError && !editor.isSaving && (
                   <>
                     <Ionicons name="alert-circle" size={14} color={colors.error} />
                     <Text style={[styles.editorFooterText, { color: colors.error }]} numberOfLines={1}>
-                      {editor.needsReauth
-                        ? t.viewer.reauthRequired
-                        : `${t.viewer.saveFailed}: ${editor.saveError}`}
+                      {`${t.viewer.saveFailed}: ${editor.saveError}`}
                     </Text>
                   </>
                 )}
-                {editor.hasUnsavedChanges && !editor.isSaving && !editor.saveSuccess && !editor.saveError && !editor.needsReauth && (
+                {editor.hasUnsavedChanges && !editor.isSaving && !editor.saveSuccess && !editor.saveError && (
                   <>
                     <View style={styles.unsavedDotSmall} />
                     <Text style={[styles.editorFooterText, { color: '#f59e0b' }]}>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,7 +5,7 @@
 export { useGoogleAuth } from './useGoogleAuth';
 export type { UseGoogleAuthReturn } from './useGoogleAuth';
 
-export { useFilePicker } from './useFilePicker';
+export { useFilePicker, getFileHandle } from './useFilePicker';
 export type { LocalFile } from './useFilePicker';
 
 export { useShare } from './useShare';

--- a/src/hooks/useFilePicker.ts
+++ b/src/hooks/useFilePicker.ts
@@ -4,4 +4,4 @@
  */
 
 export type { LocalFile } from './useFilePicker.web';
-export { useFilePicker } from './useFilePicker.web';
+export { useFilePicker, getFileHandle } from './useFilePicker.web';

--- a/src/hooks/useFilePicker.web.ts
+++ b/src/hooks/useFilePicker.web.ts
@@ -1,6 +1,6 @@
 /**
  * ファイルピッカー hook - Web 版
- * input[type=file] を使用
+ * File System Access API を使用（非対応ブラウザは input[type=file] にフォールバック）
  */
 
 import { useRef, useCallback } from 'react';
@@ -11,55 +11,104 @@ export interface LocalFile {
   content: string;
 }
 
+// FileSystemFileHandle をファイル ID で管理
+const fileHandleMap = new Map<string, FileSystemFileHandle>();
+
+export function getFileHandle(fileId: string): FileSystemFileHandle | null {
+  return fileHandleMap.get(fileId) ?? null;
+}
+
 export function useFilePicker() {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const openPicker = useCallback((): Promise<LocalFile | null> => {
-    // 既存の input があれば削除
-    if (inputRef.current) {
-      inputRef.current.remove();
+    // File System Access API 対応ブラウザ
+    if ('showOpenFilePicker' in window) {
+      return openWithFileSystemAccess();
     }
-
-    // 新しい input を作成
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.md,.markdown,text/markdown,text/x-markdown,text/plain';
-    input.style.display = 'none';
-    inputRef.current = input;
-
-    return new Promise<LocalFile | null>((resolve) => {
-      input.onchange = async (e) => {
-        const file = (e.target as HTMLInputElement).files?.[0];
-        if (!file) {
-          resolve(null);
-          input.remove();
-          return;
-        }
-
-        try {
-          const content = await file.text();
-          resolve({
-            id: `local-${Date.now()}-${file.name}`,
-            name: file.name,
-            content,
-          });
-        } catch (err) {
-          console.error('Failed to read file:', err);
-          resolve(null);
-        } finally {
-          input.remove();
-        }
-      };
-
-      input.oncancel = () => {
-        resolve(null);
-        input.remove();
-      };
-
-      document.body.appendChild(input);
-      input.click();
-    });
+    // フォールバック: input[type=file]
+    return openWithInputElement(inputRef);
   }, []);
 
   return { openPicker };
+}
+
+async function openWithFileSystemAccess(): Promise<LocalFile | null> {
+  try {
+    const [handle] = await window.showOpenFilePicker({
+      types: [
+        {
+          description: 'Markdown files',
+          accept: {
+            'text/markdown': ['.md', '.markdown'],
+            'text/plain': ['.txt'],
+          },
+        },
+      ],
+      multiple: false,
+    });
+
+    const file = await handle.getFile();
+    const content = await file.text();
+    const id = `local-${Date.now()}-${file.name}`;
+
+    // ハンドルを保存（上書き保存用）
+    fileHandleMap.set(id, handle);
+
+    return { id, name: file.name, content };
+  } catch (err) {
+    // ユーザーがキャンセルした場合
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      return null;
+    }
+    console.error('Failed to open file:', err);
+    return null;
+  }
+}
+
+function openWithInputElement(
+  inputRef: React.MutableRefObject<HTMLInputElement | null>
+): Promise<LocalFile | null> {
+  if (inputRef.current) {
+    inputRef.current.remove();
+  }
+
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.md,.markdown,text/markdown,text/x-markdown,text/plain';
+  input.style.display = 'none';
+  inputRef.current = input;
+
+  return new Promise<LocalFile | null>((resolve) => {
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) {
+        resolve(null);
+        input.remove();
+        return;
+      }
+
+      try {
+        const content = await file.text();
+        resolve({
+          id: `local-${Date.now()}-${file.name}`,
+          name: file.name,
+          content,
+        });
+      } catch (err) {
+        console.error('Failed to read file:', err);
+        resolve(null);
+      } finally {
+        input.remove();
+      }
+    };
+
+    input.oncancel = () => {
+      resolve(null);
+      input.remove();
+    };
+
+    document.body.appendChild(input);
+    input.click();
+  });
 }

--- a/src/types/file-system-access.d.ts
+++ b/src/types/file-system-access.d.ts
@@ -1,0 +1,18 @@
+/**
+ * File System Access API 型定義
+ */
+
+interface FilePickerAcceptType {
+  description?: string;
+  accept: Record<string, string[]>;
+}
+
+interface OpenFilePickerOptions {
+  multiple?: boolean;
+  excludeAcceptAllOption?: boolean;
+  types?: FilePickerAcceptType[];
+}
+
+interface Window {
+  showOpenFilePicker(options?: OpenFilePickerOptions): Promise<FileSystemFileHandle[]>;
+}


### PR DESCRIPTION
## Summary
- Google Drive 保存（`drive.file` スコープで 403 Forbidden）を廃止し、保存先をローカルに変更
- File System Access API (`showOpenFilePicker`) 対応ブラウザでは、ローカルファイルを**上書き保存**
- 非対応ブラウザ（Safari/Firefox）や Google Drive ファイルは**ダウンロード保存**にフォールバック
- `canEdit` を常に `true` にし、ソース種別に関係なく全ファイルを編集可能に
- `needsReauth` 関連ロジック・UI を削除

## Test plan
- [ ] Chrome でローカル `.md` ファイルを開き、編集 → 保存で元ファイルが上書きされることを確認
- [ ] Google Drive ファイルを開き、編集 → 保存でダウンロードされることを確認
- [ ] Safari/Firefox でローカルファイルを開き、編集 → 保存でダウンロードされることを確認
- [ ] Ctrl+S / Cmd+S ショートカットが正常に動作することを確認
- [ ] `npx tsc --noEmit` で型エラーなし
- [ ] `npm run build` でビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)