### PR TITLE
chore: drive.file スコープと updateFileContent を削除

### DIFF
--- a/src/hooks/useGoogleAuth.web.ts
+++ b/src/hooks/useGoogleAuth.web.ts
@@ -18,8 +18,8 @@ import { storage } from '../services/storage';
 const API_KEY = process.env.EXPO_PUBLIC_GOOGLE_API_KEY || '';
 const CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID || '';
 
-// Google API のスコープ（読み取り + アプリ作成ファイルの書き込み）
-const SCOPES = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file';
+// Google API のスコープ（読み取りのみ）
+const SCOPES = 'https://www.googleapis.com/auth/drive.readonly';
 
 // ストレージのキー
 const TOKEN_KEY = 'googleDriveAccessToken';

--- a/src/services/googleDrive.ts
+++ b/src/services/googleDrive.ts
@@ -188,35 +188,6 @@ export async function listRecentMarkdownFiles(
   );
 }
 
-const DRIVE_UPLOAD_API_BASE = 'https://www.googleapis.com/upload/drive/v3';
-
-/**
- * ファイル内容を更新（書き戻し）
- */
-export async function updateFileContent(
-  accessToken: string,
-  fileId: string,
-  content: string,
-): Promise<void> {
-  const response = await fetch(
-    `${DRIVE_UPLOAD_API_BASE}/files/${fileId}?uploadType=media`,
-    {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'text/markdown',
-      },
-      body: content,
-    }
-  );
-  if (!response.ok) {
-    if (response.status === 403) {
-      throw new Error('INSUFFICIENT_SCOPE');
-    }
-    throw new Error(`Failed to save: ${response.statusText}`);
-  }
-}
-
 /**
  * Markdown ファイルかどうかを判定
  */

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -14,5 +14,4 @@ export {
   searchMarkdownFiles,
   fetchFileContent,
   fetchFileInfo,
-  updateFileContent,
 } from './googleDrive';


### PR DESCRIPTION
## Summary
- OAuth スコープから `drive.file` を削除し、`drive.readonly` のみに縮小
- 不要になった `updateFileContent` 関数と `DRIVE_UPLOAD_API_BASE` 定数を削除
- `services/index.ts` のエクスポートからも削除

#86 で Google Drive 保存を廃止したことに伴うクリーンアップ。

## Test plan
- [ ] Google Drive ファイルの読み込みが引き続き動作すること
- [ ] `npx tsc --noEmit` で型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)