### PR TITLE
feat: React Router 7 ルーティング移行 (Vite移行 2/7)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-web": "~0.21.0",
+        "react-router": "^7.13.0",
         "react-syntax-highlighter": "^16.1.0",
         "remark-gfm": "^4.0.1",
       },
@@ -877,6 +878,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "core-js": ["core-js@3.48.0", "", {}, "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ=="],
 
     "core-js-compat": ["core-js-compat@3.48.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q=="],
@@ -1627,6 +1630,8 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
+    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
+
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-syntax-highlighter": ["react-syntax-highlighter@16.1.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "highlight.js": "^10.4.1", "highlightjs-vue": "^1.0.0", "lowlight": "^1.17.0", "prismjs": "^1.30.0", "refractor": "^5.0.0" }, "peerDependencies": { "react": ">= 0.14.0" } }, "sha512-E40/hBiP5rCNwkeBN1vRP+xow1X0pndinO+z3h7HLsHyjztbyjfzNWNKuAsJj+7DLam9iT4AaaOZnueCU+Nplg=="],
@@ -1702,6 +1707,8 @@
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 

--- a/index.html
+++ b/index.html
@@ -45,6 +45,10 @@
         width: 100%;
         height: 100%;
       }
+      #root {
+        display: flex;
+        flex-direction: column;
+      }
       html {
         scroll-behavior: smooth;
       }
@@ -80,12 +84,16 @@
       }
     </style>
 
+    <!-- Ionicons (for Vite build) -->
+    <script type="module" src="https://unpkg.com/ionicons@7.4.0/dist/ionicons/ionicons.esm.js"></script>
+
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKEK6L4D33"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-YKEK6L4D33');</script>
   </head>
   <body>
     <div id="root"></div>
+    <script>var global = globalThis;</script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
+    "react-router": "^7.13.0",
     "react-syntax-highlighter": "^16.1.0",
     "remark-gfm": "^4.0.1"
   },

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,0 +1,38 @@
+import { Outlet } from 'react-router';
+import { View, StyleSheet } from 'react-native';
+import { SpeedInsights } from '@vercel/speed-insights/react';
+import { ThemeProvider } from '../contexts/ThemeContext';
+import { LanguageProvider } from '../contexts/LanguageContext';
+import { FontSettingsProvider } from '../contexts/FontSettingsContext';
+import { useTheme } from '../hooks';
+import { useRouterSetup } from '../shims/expo-router';
+
+function RootLayoutContent() {
+  const { colors } = useTheme();
+  useRouterSetup();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
+      <Outlet />
+      <SpeedInsights />
+    </View>
+  );
+}
+
+export default function RootLayout() {
+  return (
+    <ThemeProvider>
+      <LanguageProvider>
+        <FontSettingsProvider>
+          <RootLayoutContent />
+        </FontSettingsProvider>
+      </LanguageProvider>
+    </ThemeProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,26 +1,7 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { SpeedInsights } from '@vercel/speed-insights/react';
-import { ThemeProvider } from './contexts/ThemeContext';
-import { LanguageProvider } from './contexts/LanguageContext';
-import { FontSettingsProvider } from './contexts/FontSettingsContext';
-import HomeScreen from '../app/index';
-
-function App() {
-  return (
-    <ThemeProvider>
-      <LanguageProvider>
-        <FontSettingsProvider>
-          <HomeScreen />
-          <SpeedInsights />
-        </FontSettingsProvider>
-      </LanguageProvider>
-    </ThemeProvider>
-  );
-}
+import { RouterProvider } from 'react-router';
+import { router } from './router';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <RouterProvider router={router} />
 );

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,47 @@
+import { useRouteError, Link } from 'react-router';
+import { View, Text, StyleSheet } from 'react-native';
+import { spacing, fontSize, fontWeight } from '../theme';
+
+export default function ErrorPage() {
+  const error = useRouteError();
+
+  const message =
+    error instanceof Error
+      ? error.message
+      : 'An unexpected error occurred.';
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Something went wrong</Text>
+      <Text style={styles.message}>{message}</Text>
+      <Link to="/" style={{ marginTop: spacing.md }}>
+        <Text style={styles.linkText}>Go to Home</Text>
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.xl,
+    backgroundColor: '#f5f5f5',
+  },
+  title: {
+    fontSize: fontSize.xl,
+    fontWeight: fontWeight.semibold,
+    marginBottom: spacing.md,
+    color: '#333',
+  },
+  message: {
+    fontSize: fontSize.base,
+    color: '#666',
+    textAlign: 'center',
+  },
+  linkText: {
+    fontSize: fontSize.base,
+    color: '#4285f4',
+  },
+});

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../hooks';
+import { spacing, fontSize, fontWeight } from '../theme';
+
+export default function NotFoundPage() {
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bgPrimary }]}>
+      <Text style={[styles.title, { color: colors.textPrimary }]}>Page Not Found</Text>
+      <Link to="/" style={{ marginTop: spacing.md }}>
+        <Text style={[styles.linkText, { color: colors.accent }]}>Go to Home</Text>
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.xl,
+  },
+  title: {
+    fontSize: fontSize.xl,
+    fontWeight: fontWeight.semibold,
+    marginBottom: spacing.lg,
+  },
+  linkText: {
+    fontSize: fontSize.base,
+  },
+});

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,31 @@
+import { createBrowserRouter } from 'react-router';
+import RootLayout from './layouts/RootLayout';
+import ErrorPage from './pages/ErrorPage';
+import NotFoundPage from './pages/NotFoundPage';
+import HomeScreen from '../app/index';
+import ViewerScreen from '../app/viewer';
+import SearchScreen from '../app/search';
+import AboutScreen from '../app/about';
+import PrivacyScreen from '../app/privacy';
+import TermsScreen from '../app/terms';
+import LicenseScreen from '../app/license';
+import ThirdPartyLicensesScreen from '../app/third-party-licenses';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <RootLayout />,
+    errorElement: <ErrorPage />,
+    children: [
+      { index: true, element: <HomeScreen /> },
+      { path: 'viewer', element: <ViewerScreen /> },
+      { path: 'search', element: <SearchScreen /> },
+      { path: 'about', element: <AboutScreen /> },
+      { path: 'privacy', element: <PrivacyScreen /> },
+      { path: 'terms', element: <TermsScreen /> },
+      { path: 'license', element: <LicenseScreen /> },
+      { path: 'third-party-licenses', element: <ThirdPartyLicensesScreen /> },
+      { path: '*', element: <NotFoundPage /> },
+    ],
+  },
+]);

--- a/src/shims/expo-router.tsx
+++ b/src/shims/expo-router.tsx
@@ -1,24 +1,108 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  Link as RRLink,
+  useSearchParams,
+  useLocation,
+  useNavigate,
+} from 'react-router';
+
+// Module-level navigate function, initialized by useRouterSetup()
+let _navigate: ReturnType<typeof useNavigate> | null = null;
+
+/**
+ * Call this hook once in RootLayout to wire up the module-level navigate.
+ */
+export function useRouterSetup() {
+  const navigate = useNavigate();
+  React.useEffect(() => {
+    _navigate = navigate;
+    return () => {
+      _navigate = null;
+    };
+  }, [navigate]);
+}
+
+function buildPath(
+  route: string | { pathname: string; params?: Record<string, string> },
+  options?: { replace?: boolean },
+) {
+  if (typeof route === 'string') {
+    return { to: route, state: undefined, replace: options?.replace };
+  }
+
+  const { pathname, params } = route;
+
+  // Separate "content" (large data) into location.state,
+  // and put the rest into search params.
+  const stateData: Record<string, string> = {};
+  const searchData: Record<string, string> = {};
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (key === 'content') {
+        stateData[key] = value;
+      } else {
+        searchData[key] = value;
+      }
+    }
+  }
+
+  const search = new URLSearchParams(searchData).toString();
+  const to = search ? `${pathname}?${search}` : pathname;
+
+  return {
+    to,
+    state: Object.keys(stateData).length > 0 ? stateData : undefined,
+    replace: options?.replace,
+  };
+}
 
 export const router = {
-  push: (route: string | { pathname: string; params?: Record<string, string> }) => {
-    console.warn('[expo-router shim] router.push called:', route);
+  push(route: string | { pathname: string; params?: Record<string, string> }) {
+    if (!_navigate) {
+      console.warn('[expo-router shim] navigate not initialized. Did you call useRouterSetup()?');
+      return;
+    }
+    const { to, state, replace } = buildPath(route);
+    _navigate(to, { state, replace });
   },
-  back: () => {
-    console.warn('[expo-router shim] router.back called');
+  back() {
+    if (!_navigate) {
+      console.warn('[expo-router shim] navigate not initialized. Did you call useRouterSetup()?');
+      return;
+    }
+    _navigate(-1);
   },
-  replace: (route: string | { pathname: string; params?: Record<string, string> }) => {
-    console.warn('[expo-router shim] router.replace called:', route);
+  replace(route: string | { pathname: string; params?: Record<string, string> }) {
+    if (!_navigate) {
+      console.warn('[expo-router shim] navigate not initialized. Did you call useRouterSetup()?');
+      return;
+    }
+    const { to, state } = buildPath(route, { replace: true });
+    _navigate(to, { state, replace: true });
   },
 };
 
-export function Link({ href, children, style, ...props }: {
+export function Link({
+  href,
+  children,
+  style,
+  ...props
+}: {
   href: string;
   children: React.ReactNode;
-  style?: object;
+  style?: unknown;
   [key: string]: unknown;
 }) {
-  return <a href={href} style={style} {...props}>{children}</a>;
+  // Flatten RN style arrays (e.g. [styles.foo, { color: 'red' }]) into a plain object
+  // so DOM elements can consume them.
+  const flatStyle = style ? (StyleSheet.flatten(style as never) as React.CSSProperties) : undefined;
+  return (
+    <RRLink to={href} style={flatStyle} {...props}>
+      {children}
+    </RRLink>
+  );
 }
 
 export function Stack() {
@@ -28,8 +112,29 @@ Stack.Screen = function StackScreen() {
   return null;
 };
 
-export function useLocalSearchParams(): Record<string, string> {
-  return {};
+export function useLocalSearchParams<
+  T extends Record<string, string> = Record<string, string>,
+>(): T {
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
+
+  return React.useMemo(() => {
+    const result: Record<string, string> = {};
+
+    // Merge URL search params
+    searchParams.forEach((value, key) => {
+      result[key] = value;
+    });
+
+    // Merge location.state (overrides search params for same keys)
+    if (location.state && typeof location.state === 'object') {
+      for (const [key, value] of Object.entries(location.state as Record<string, string>)) {
+        result[key] = value;
+      }
+    }
+
+    return result as T;
+  }, [searchParams, location.state]);
 }
 
 export function ErrorBoundary() {

--- a/src/shims/expo-vector-icons.tsx
+++ b/src/shims/expo-vector-icons.tsx
@@ -1,19 +1,27 @@
 import React from 'react';
-import { Text } from 'react-native';
 
 interface IconProps {
   name: string;
   size?: number;
   color?: string;
-  style?: object;
+  style?: React.CSSProperties;
 }
 
 function Ionicons({ name, size = 24, color = '#000', style }: IconProps) {
-  return (
-    <Text style={[{ fontSize: size, color }, style]} aria-label={name}>
-      ?
-    </Text>
-  );
+  return React.createElement('ion-icon', {
+    name,
+    style: {
+      fontSize: `${size}px`,
+      color,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: `${size}px`,
+      height: `${size}px`,
+      pointerEvents: 'none',
+      ...style,
+    } as React.CSSProperties,
+  });
 }
 
 export { Ionicons };


### PR DESCRIPTION
## Summary
- Vite ビルドに React Router 7 を導入し、全画面のルーティングを実装
- `app/` ファイルは変更せず、`src/shims/expo-router.tsx` で Expo Router API を React Router 7 に委譲し互換性を維持
- Vite + react-native-web 環境で発生する複数の実行時エラーを修正

## Changes

### ルーティング
- `react-router` v7 を追加
- `src/router.tsx`: `createBrowserRouter` で全8画面 + 404 のルート定義
- `src/layouts/RootLayout.tsx`: Provider 階層 + `<Outlet />` + `useRouterSetup()`
- `src/pages/NotFoundPage.tsx`, `src/pages/ErrorPage.tsx`: エラーページ
- `src/main.tsx`: `<RouterProvider>` に変更

### Shims (expo-router → react-router)
- `router.push/back/replace` → `useNavigate` 委譲（モジュールレベル `_navigate` パターン）
- `Link` → React Router `<Link>` + `StyleSheet.flatten()` で RN style arrays 対応
- `useLocalSearchParams` → `useSearchParams` + `useLocation().state` マージ
- `content` パラメータは `location.state` 経由（URL params ではなく）

### Vite + react-native-web 互換修正
- `vite.config.ts`: Metro `require()` → `new URL()` 変換プラグイン追加
- `index.html`: `global = globalThis` polyfill、`#root` flex layout、ionicons CDN
- `src/shims/expo-vector-icons.tsx`: ionicons Web Component (`<ion-icon>`) に変更
- `src/main.tsx`: `React.StrictMode` 除去（react-native-web Animated 非互換）

## Test plan
- [x] `bun run build:vite` ビルドエラーなし
- [x] `bun run test` 全83テスト合格
- [x] `/` ホーム画面表示
- [x] ハンバーガーメニュー開閉（Animated スライドイン）
- [x] アイコン表示（ionicons）
- [x] スクロール動作
- [x] ページ遷移（viewer, search, about, privacy, terms, license, third-party-licenses）
- [x] ブラウザバック
- [x] 存在しない URL で 404 ページ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)