### PR TITLE
feat: トップページの説明文章を why.md に基づいて改善

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -5,37 +5,37 @@
 export const en = {
   // Home Screen
   home: {
-    welcomeLine1: 'Beautiful Markdown',
-    welcomeLine2: 'for ',
-    welcomeHighlight: 'Google Drive',
-    subtitle: 'Preview your .md files with syntax highlighting, diagrams, and PDF export — all in your browser.',
+    welcomeLine1: 'Bring Markdown Previews',
+    welcomeLine2: 'to ',
+    welcomeHighlight: 'Google Drive.',
+    subtitle: 'Preview Markdown files directly in your browser without downloading. Upgrade your Google Drive experience instantly.',
     feature: {
       drive: {
         title: 'Google Drive Integration',
-        desc: 'Search and open Markdown files directly from your Google Drive',
+        desc: 'Search and preview Markdown files directly from Drive — no downloads needed',
       },
       rendering: {
-        title: 'Beautiful Rendering',
-        desc: 'Syntax highlighting, Mermaid diagrams, and clean typography',
+        title: 'Professional Rendering',
+        desc: 'GFM tables, task lists, clean typography, and beautiful output ready for sharing',
       },
       pdf: {
         title: 'Export to PDF',
-        desc: 'Share your documents as beautifully formatted PDFs',
+        desc: 'Generate PDFs for documentation review and team sharing in one click',
       },
       syntax: {
         title: 'Syntax Highlighting',
-        desc: 'Code blocks with highlighting for all major programming languages',
+        desc: 'Code blocks rendered with highlighting for all major languages',
       },
       mermaid: {
         title: 'Mermaid Diagrams',
-        desc: 'Flowcharts, sequence diagrams, and more rendered automatically',
+        desc: 'Flowcharts, sequence diagrams, and ER diagrams rendered automatically',
       },
       local: {
         title: 'Local File Support',
-        desc: 'Open Markdown files from your device without signing in',
+        desc: 'Open Markdown files from your device — no sign-in or upload required',
       },
     },
-    tagline: 'Free. Open source. No server storage.',
+    tagline: 'Privacy-first. Open source. Your files never leave your browser.',
     previewTitle: 'See it in action',
     previewCaption: 'Dark and light themes supported',
     howItWorks: {
@@ -53,8 +53,8 @@ export const en = {
         desc: 'Enjoy beautifully rendered documents instantly',
       },
     },
-    featuresTitle: 'Everything you need',
-    techTitle: 'Your data stays\nwith you',
+    featuresTitle: 'Everything for technical docs',
+    techTitle: 'Serverless by design.\nYour data stays with you.',
     stats: {
       clientSide: { value: '100%', label: 'Client-side' },
       serverStorage: { value: '0', label: 'Server storage' },
@@ -63,20 +63,20 @@ export const en = {
     benefit: {
       privacy: {
         title: 'Privacy First',
-        desc: 'Your files never leave your browser. No server storage, no tracking of your documents.',
+        desc: 'Files go directly from Google Drive to your browser — no intermediary server. Safe for confidential docs and compliant with enterprise security policies.',
       },
       instant: {
         title: 'Instant Access',
-        desc: 'No downloads or installs needed. Open any Markdown file directly from Google Drive.',
+        desc: 'No downloads, no installs, no setup. Sign in with Google and start previewing Markdown in seconds.',
       },
       beautiful: {
         title: 'Beautiful Output',
-        desc: 'Professional rendering with syntax highlighting, diagrams, and PDF export.',
+        desc: 'Syntax highlighting, Mermaid diagrams, GFM tables, and one-click PDF export — everything technical writers and engineers need.',
       },
     },
     closingCta: {
-      title: 'Ready to get started?',
-      subtitle: 'View your Google Drive Markdown files beautifully — free and private.',
+      title: 'Open your first Markdown file',
+      subtitle: 'Connect your Google Drive for free — or try with a local file.',
     },
     footer: {
       builtWith: 'Built with Vite and React',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -7,37 +7,37 @@ import type { Translations } from './en';
 export const ja: Translations = {
   // Home Screen
   home: {
-    welcomeLine1: 'Beautiful Markdown',
-    welcomeLine2: 'for ',
-    welcomeHighlight: 'Google Drive',
-    subtitle: 'シンタックスハイライト、図表、PDF出力に対応した .md ファイルプレビュー — すべてブラウザ上で。',
+    welcomeLine1: 'Google Drive に、',
+    welcomeLine2: '',
+    welcomeHighlight: 'Markdown のプレビューを。',
+    subtitle: 'Markdownファイルをダウンロードせずに、ブラウザ上でそのまま確認。あなたの Google Drive をもっと便利にアップグレードします。',
     feature: {
       drive: {
         title: 'Google Drive連携',
-        desc: 'Google Driveから直接Markdownファイルを検索・表示',
+        desc: 'Drive内のMarkdownファイルを検索・プレビュー。ダウンロード不要',
       },
       rendering: {
-        title: '美しいレンダリング',
-        desc: 'シンタックスハイライト、Mermaid図表、美しいタイポグラフィ',
+        title: 'プロフェッショナルな表示',
+        desc: 'GFMテーブル、タスクリスト、美しいタイポグラフィで共有に最適な出力',
       },
       pdf: {
         title: 'PDF出力',
-        desc: 'ドキュメントを美しいPDFとして共有',
+        desc: 'ワンクリックでPDFを生成。レビューやチーム共有に',
       },
       syntax: {
         title: 'シンタックスハイライト',
-        desc: '主要なプログラミング言語のコードブロックをハイライト表示',
+        desc: '主要プログラミング言語のコードブロックをハイライト表示',
       },
       mermaid: {
         title: 'Mermaid図表',
-        desc: 'フローチャートやシーケンス図などを自動レンダリング',
+        desc: 'フローチャート、シーケンス図、ER図を自動レンダリング',
       },
       local: {
         title: 'ローカルファイル対応',
-        desc: 'サインインなしでデバイスのMarkdownファイルを開けます',
+        desc: 'サインインもアップロードも不要。デバイスのファイルをそのまま開けます',
       },
     },
-    tagline: '無料。オープンソース。サーバー保存なし。',
+    tagline: 'プライバシー重視。オープンソース。ファイルはブラウザから出ません。',
     previewTitle: '実際の画面',
     previewCaption: 'ダーク・ライトテーマ対応',
     howItWorks: {
@@ -55,30 +55,30 @@ export const ja: Translations = {
         desc: '美しくレンダリングされたドキュメントを即座に閲覧',
       },
     },
-    featuresTitle: '充実の機能',
-    techTitle: 'あなたのデータは\nあなたの手元に',
+    featuresTitle: '技術ドキュメントに必要なすべて',
+    techTitle: 'サーバーレス設計。\nデータはあなたの手元に。',
     stats: {
       clientSide: { value: '100%', label: 'クライアントサイド' },
       serverStorage: { value: '0', label: 'サーバー保存' },
     },
-    benefitsTitle: 'MarkDriveの特長',
+    benefitsTitle: 'なぜMarkDrive？',
     benefit: {
       privacy: {
-        title: 'プライバシー重視',
-        desc: 'ファイルはブラウザから出ません。サーバー保存なし、ドキュメントの追跡なし。',
+        title: 'プライバシーファースト',
+        desc: 'ファイルはGoogle Driveからブラウザに直接送信。中間サーバーは介在しません。機密文書も安心して閲覧でき、企業のセキュリティポリシーにも準拠します。',
       },
       instant: {
         title: '即時アクセス',
-        desc: 'ダウンロードやインストール不要。Google DriveのMarkdownファイルを直接開けます。',
+        desc: 'ダウンロード不要、インストール不要、セットアップ不要。Googleでサインインするだけで、すぐにMarkdownプレビューを始められます。',
       },
       beautiful: {
         title: '美しい出力',
-        desc: 'シンタックスハイライト、図表、PDF出力によるプロフェッショナルなレンダリング。',
+        desc: 'シンタックスハイライト、Mermaid図表、GFMテーブル、ワンクリックPDF出力 — エンジニアやテクニカルライターに必要なものがすべて揃っています。',
       },
     },
     closingCta: {
-      title: 'さっそく使ってみる',
-      subtitle: 'Google DriveのMarkdownを、きれいに表示。無料で、データはあなたの手元に。',
+      title: '最初のMarkdownを開いてみよう',
+      subtitle: 'Google Driveに無料で接続 — またはローカルファイルで試す。',
     },
     footer: {
       builtWith: 'Vite + React で構築',


### PR DESCRIPTION
## Summary
- ヒーローコピーを課題起点に変更 ("Bring Markdown Previews to Google Drive" / "Google Drive に、Markdown のプレビューを。")
- サブコピー、tagline、機能説明、Benefits、CTA を why.md の価値提案に基づいて改善
- EN/JA 両方を更新

## Test plan
- [ ] `bunx tsc --noEmit` 型チェック通過済み
- [ ] 開発サーバーで EN/JA 両方のトップページ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)