### PR TITLE
feat: ヒーローコピーを3行構造に変更

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -5,9 +5,9 @@
 export const en = {
   // Home Screen
   home: {
-    welcomeLine1: 'Bring Markdown Previews',
-    welcomeLine2: 'to ',
-    welcomeHighlight: 'Google Drive.',
+    welcomeLine1: 'Bring',
+    welcomeLine2: 'to Google Drive.',
+    welcomeHighlight: 'Markdown Previews',
     subtitle: 'Preview Markdown files directly in your browser without downloading. Upgrade your Google Drive experience instantly.',
     feature: {
       drive: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -7,9 +7,9 @@ import type { Translations } from './en';
 export const ja: Translations = {
   // Home Screen
   home: {
-    welcomeLine1: 'Google Drive に、',
-    welcomeLine2: '',
-    welcomeHighlight: 'Markdown のプレビューを。',
+    welcomeLine1: 'Bring',
+    welcomeLine2: 'to Google Drive.',
+    welcomeHighlight: 'Markdown Previews',
     subtitle: 'Markdownファイルをダウンロードせずに、ブラウザ上でそのまま確認。あなたの Google Drive をもっと便利にアップグレードします。',
     feature: {
       drive: {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -266,8 +266,9 @@ export default function HomePage() {
                   <h1 className={styles.heroTitle}>
                     {t.home.welcomeLine1}
                     <br />
-                    {t.home.welcomeLine2}
                     <span className={styles.heroHighlight}>{t.home.welcomeHighlight}</span>
+                    <br />
+                    {t.home.welcomeLine2}
                   </h1>
                   <p className={styles.heroSubtitle}>
                     {t.home.subtitle}


### PR DESCRIPTION
## Summary
- ヒーローを「Bring / Markdown Previews / to Google Drive.」の3行構成に変更
- ハイライト対象を Google Drive → Markdown Previews に変更（プロダクトの価値を強調）
- EN/JA 共通テキストに統一

## Test plan
- [x] `bunx tsc --noEmit` 型チェック通過済み
- [ ] 開発サーバーでヒーローの3行表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)