### PR TITLE
test: テストカバレッジを67%→80%に改善

### DIFF
--- a/src/components/markdown/MarkdownRenderer.test.tsx
+++ b/src/components/markdown/MarkdownRenderer.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+// Mock useTheme
+vi.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      bgPrimary: '#0a0b14',
+      bgSecondary: '#111320',
+      bgTertiary: '#1a1d2e',
+      bgCard: '#151729',
+      accent: '#6366f1',
+      accentHover: '#818cf8',
+      accentMuted: 'rgba(99,102,241,0.12)',
+      textPrimary: '#e2e8f0',
+      textSecondary: '#94a3b8',
+      textMuted: '#475569',
+      border: '#1e2038',
+      borderLight: '#2a2d45',
+      error: '#ef4444',
+      warning: '#f59e0b',
+      warningMuted: 'rgba(245,158,11,0.12)',
+      success: '#10b981',
+      overlay: 'rgba(0,0,0,0.6)',
+      overlayLight: 'rgba(0,0,0,0.3)',
+      shadowColor: 'rgba(0,0,0,0.4)',
+    },
+    resolvedMode: 'dark' as const,
+  }),
+}));
+
+// Mock useFontSettings
+vi.mock('../../contexts/FontSettingsContext', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../contexts/FontSettingsContext')>();
+  return {
+    ...original,
+    useFontSettings: () => ({
+      settings: {
+        fontSize: 'medium' as const,
+        fontFamily: 'system' as const,
+      },
+      setFontSize: vi.fn(),
+      setFontFamily: vi.fn(),
+      getMultiplier: () => 1.0,
+      getFontStack: () => 'system-ui',
+    }),
+  };
+});
+
+// Mock mermaid
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async () => ({ svg: '<svg>test</svg>' })),
+  },
+}));
+
+describe('MarkdownRenderer', () => {
+  it('should render basic markdown content', () => {
+    render(<MarkdownRenderer content="Hello **world**" />);
+    expect(screen.getByText('world')).toBeTruthy();
+  });
+
+  it('should render headings', () => {
+    render(<MarkdownRenderer content="# Title" />);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading.textContent).toBe('Title');
+  });
+
+  it('should render links with target blank', () => {
+    render(<MarkdownRenderer content="[Link](https://example.com)" />);
+    const link = screen.getByText('Link');
+    expect(link.closest('a')?.getAttribute('target')).toBe('_blank');
+    expect(link.closest('a')?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('should render inline code', () => {
+    render(<MarkdownRenderer content="Use `code` here" />);
+    const code = screen.getByText('code');
+    expect(code.className).toBe('inline-code');
+  });
+
+  it('should inject generated styles', () => {
+    const { container } = render(<MarkdownRenderer content="test" />);
+    const styleTag = container.querySelector('style');
+    expect(styleTag).toBeTruthy();
+    expect(styleTag!.innerHTML).toContain('.markdown-content');
+    expect(styleTag!.innerHTML).toContain('font-size:');
+  });
+
+  it('should render tables with wrapper', () => {
+    const tableMarkdown = `
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+`;
+    const { container } = render(<MarkdownRenderer content={tableMarkdown} />);
+    const wrapper = container.querySelector('.table-wrapper');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper!.querySelector('table')).toBeTruthy();
+  });
+
+  it('should render images with lazy loading', () => {
+    render(<MarkdownRenderer content="![Alt text](https://example.com/image.png)" />);
+    const img = screen.getByAltText('Alt text');
+    expect(img.getAttribute('loading')).toBe('lazy');
+  });
+});

--- a/src/hooks/useAddToHomeScreen.test.ts
+++ b/src/hooks/useAddToHomeScreen.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAddToHomeScreen } from './useAddToHomeScreen';
+
+function createLocalStorageMock() {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  };
+}
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: ua,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function setPlatform(platform: string) {
+  Object.defineProperty(navigator, 'platform', {
+    value: platform,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function setMaxTouchPoints(count: number) {
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    value: count,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function setStandalone(value: boolean) {
+  Object.defineProperty(navigator, 'standalone', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('useAddToHomeScreen', () => {
+  let storageMock: ReturnType<typeof createLocalStorageMock>;
+  const originalUserAgent = navigator.userAgent;
+
+  beforeEach(() => {
+    storageMock = createLocalStorageMock();
+    Object.defineProperty(window, 'localStorage', {
+      value: storageMock,
+      writable: true,
+      configurable: true,
+    });
+    // Default: not standalone
+    setStandalone(false);
+  });
+
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+    setPlatform('');
+    setMaxTouchPoints(0);
+    setStandalone(false);
+  });
+
+  describe('iOS Safari detection', () => {
+    it('should show banner on iOS Safari (iPhone)', () => {
+      setUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      );
+      setPlatform('iPhone');
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(true);
+    });
+
+    it('should show banner on iPad (with MacIntel + touchpoints)', () => {
+      setUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+      );
+      setPlatform('MacIntel');
+      setMaxTouchPoints(5);
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(true);
+    });
+
+    it('should not show banner on Chrome on iOS (CriOS)', () => {
+      setUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0 Mobile/15E148 Safari/604.1'
+      );
+      setPlatform('iPhone');
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(false);
+    });
+
+    it('should not show banner on desktop browser', () => {
+      setUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36'
+      );
+      setPlatform('MacIntel');
+      setMaxTouchPoints(0);
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(false);
+    });
+  });
+
+  describe('standalone detection', () => {
+    it('should not show banner when running as standalone app', () => {
+      setUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      );
+      setPlatform('iPhone');
+      setStandalone(true);
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(false);
+    });
+
+    it('should return isStandalone status', () => {
+      setStandalone(true);
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.isStandalone).toBe(true);
+    });
+  });
+
+  describe('dismiss', () => {
+    it('should hide banner and persist dismiss timestamp', () => {
+      setUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      );
+      setPlatform('iPhone');
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(true);
+
+      act(() => {
+        result.current.dismiss();
+      });
+
+      expect(result.current.shouldShow).toBe(false);
+      expect(storageMock.setItem).toHaveBeenCalledWith(
+        'markdrive-a2hs-dismissed',
+        expect.any(String)
+      );
+    });
+
+    it('should not show banner when recently dismissed', () => {
+      setUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      );
+      setPlatform('iPhone');
+
+      // Simulate recent dismiss (1 day ago)
+      const oneDayAgo = String(Date.now() - 1 * 24 * 60 * 60 * 1000);
+      storageMock.setItem('markdrive-a2hs-dismissed', oneDayAgo);
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(false);
+    });
+
+    it('should show banner when dismiss has expired (>7 days)', () => {
+      setUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      );
+      setPlatform('iPhone');
+
+      // Simulate old dismiss (8 days ago)
+      const eightDaysAgo = String(Date.now() - 8 * 24 * 60 * 60 * 1000);
+      storageMock.setItem('markdrive-a2hs-dismissed', eightDaysAgo);
+
+      const { result } = renderHook(() => useAddToHomeScreen());
+      expect(result.current.shouldShow).toBe(true);
+    });
+  });
+});

--- a/src/hooks/useMarkdownEditor.test.ts
+++ b/src/hooks/useMarkdownEditor.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMarkdownEditor } from './useMarkdownEditor';
+
+describe('useMarkdownEditor', () => {
+  const defaultOptions = {
+    initialContent: '# Hello',
+    fileName: 'test.md',
+    fileHandle: null,
+    onContentSaved: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('should start in preview mode', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+      expect(result.current.mode).toBe('preview');
+    });
+
+    it('should have canEdit true', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+      expect(result.current.canEdit).toBe(true);
+    });
+
+    it('should have no unsaved changes initially', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+      expect(result.current.hasUnsavedChanges).toBe(false);
+    });
+
+    it('should have canSave false initially', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+      expect(result.current.canSave).toBe(false);
+    });
+  });
+
+  describe('toggleMode', () => {
+    it('should switch from preview to edit', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+
+      act(() => {
+        result.current.toggleMode();
+      });
+
+      expect(result.current.mode).toBe('edit');
+      expect(result.current.editContent).toBe('# Hello');
+    });
+
+    it('should switch from edit back to preview', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+
+      act(() => {
+        result.current.toggleMode();
+      });
+      act(() => {
+        result.current.toggleMode();
+      });
+
+      expect(result.current.mode).toBe('preview');
+    });
+  });
+
+  describe('hasUnsavedChanges / canSave', () => {
+    it('should detect unsaved changes when content differs from initial', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+
+      act(() => {
+        result.current.toggleMode();
+      });
+      act(() => {
+        result.current.setEditContent('# Modified');
+      });
+
+      expect(result.current.hasUnsavedChanges).toBe(true);
+      expect(result.current.canSave).toBe(true);
+    });
+
+    it('should have no unsaved changes when content matches initial', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+
+      act(() => {
+        result.current.toggleMode();
+      });
+      act(() => {
+        result.current.setEditContent('# Modified');
+      });
+      act(() => {
+        result.current.setEditContent('# Hello');
+      });
+
+      expect(result.current.hasUnsavedChanges).toBe(false);
+      expect(result.current.canSave).toBe(false);
+    });
+
+    it('should report no unsaved changes in preview mode', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+      expect(result.current.hasUnsavedChanges).toBe(false);
+    });
+  });
+
+  describe('discardChanges', () => {
+    it('should reset content and return to preview mode', () => {
+      const { result } = renderHook(() => useMarkdownEditor(defaultOptions));
+
+      act(() => {
+        result.current.toggleMode();
+      });
+      act(() => {
+        result.current.setEditContent('# Modified');
+      });
+      act(() => {
+        result.current.discardChanges();
+      });
+
+      expect(result.current.mode).toBe('preview');
+      expect(result.current.editContent).toBe('# Hello');
+      expect(result.current.hasUnsavedChanges).toBe(false);
+    });
+  });
+
+  describe('save', () => {
+    it('should download file when no fileHandle (fallback)', async () => {
+      const createObjectURL = vi.fn(() => 'blob:test');
+      const revokeObjectURL = vi.fn();
+      const clickMock = vi.fn();
+
+      Object.defineProperty(window, 'URL', {
+        value: { createObjectURL, revokeObjectURL },
+        writable: true,
+        configurable: true,
+      });
+
+      const onContentSaved = vi.fn();
+      const { result } = renderHook(() =>
+        useMarkdownEditor({ ...defaultOptions, onContentSaved })
+      );
+
+      act(() => {
+        result.current.toggleMode();
+      });
+      act(() => {
+        result.current.setEditContent('# New Content');
+      });
+
+      // Mock createElement AFTER renderHook to avoid interfering with it
+      const origCreateElement = document.createElement.bind(document);
+      const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'a') {
+          return { href: '', download: '', click: clickMock } as unknown as HTMLAnchorElement;
+        }
+        return origCreateElement(tag);
+      });
+
+      let saveResult: boolean;
+      await act(async () => {
+        saveResult = await result.current.save();
+      });
+
+      expect(saveResult!).toBe(true);
+      expect(clickMock).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalled();
+      expect(onContentSaved).toHaveBeenCalledWith('# New Content');
+      expect(result.current.saveSuccess).toBe(true);
+      expect(result.current.hasUnsavedChanges).toBe(false);
+
+      createElementSpy.mockRestore();
+    });
+
+    it('should save via fileHandle when available', async () => {
+      const writeMock = vi.fn();
+      const closeMock = vi.fn();
+      const fileHandle = {
+        createWritable: vi.fn(async () => ({
+          write: writeMock,
+          close: closeMock,
+        })),
+      } as unknown as FileSystemFileHandle;
+
+      const onContentSaved = vi.fn();
+      const { result } = renderHook(() =>
+        useMarkdownEditor({
+          ...defaultOptions,
+          fileHandle,
+          onContentSaved,
+        })
+      );
+
+      act(() => {
+        result.current.toggleMode();
+      });
+      act(() => {
+        result.current.setEditContent('# Saved via handle');
+      });
+
+      let saveResult: boolean;
+      await act(async () => {
+        saveResult = await result.current.save();
+      });
+
+      expect(saveResult!).toBe(true);
+      expect(writeMock).toHaveBeenCalledWith('# Saved via handle');
+      expect(closeMock).toHaveBeenCalled();
+      expect(onContentSaved).toHaveBeenCalledWith('# Saved via handle');
+    });
+
+    it('should handle save error', async () => {
+      const fileHandle = {
+        createWritable: vi.fn(async () => {
+          throw new Error('Permission denied');
+        }),
+      } as unknown as FileSystemFileHandle;
+
+      const { result } = renderHook(() =>
+        useMarkdownEditor({ ...defaultOptions, fileHandle })
+      );
+
+      act(() => {
+        result.current.toggleMode();
+      });
+      act(() => {
+        result.current.setEditContent('# Will fail');
+      });
+
+      let saveResult: boolean;
+      await act(async () => {
+        saveResult = await result.current.save();
+      });
+
+      expect(saveResult!).toBe(false);
+      expect(result.current.saveError).toBe('Permission denied');
+      expect(result.current.isSaving).toBe(false);
+    });
+  });
+
+  describe('initialContent change', () => {
+    it('should update baseline when initialContent changes', () => {
+      const { result, rerender } = renderHook(
+        (props) => useMarkdownEditor(props),
+        { initialProps: defaultOptions }
+      );
+
+      rerender({ ...defaultOptions, initialContent: '# Updated' });
+
+      act(() => {
+        result.current.toggleMode();
+      });
+
+      expect(result.current.editContent).toBe('# Updated');
+    });
+  });
+
+  describe('null initialContent', () => {
+    it('should use empty string as baseline when initialContent is null', () => {
+      const { result } = renderHook(() =>
+        useMarkdownEditor({ ...defaultOptions, initialContent: null })
+      );
+
+      act(() => {
+        result.current.toggleMode();
+      });
+
+      expect(result.current.editContent).toBe('');
+    });
+  });
+});

--- a/src/pages/ErrorPage.test.tsx
+++ b/src/pages/ErrorPage.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ErrorPage from './ErrorPage';
+
+const mockUseRouteError = vi.fn();
+
+vi.mock('react-router', () => ({
+  useRouteError: () => mockUseRouteError(),
+  Link: ({ to, children, className }: { to: string; children: React.ReactNode; className?: string }) => (
+    <a href={to} className={className}>{children}</a>
+  ),
+}));
+
+describe('ErrorPage', () => {
+  it('should display Error instance message', () => {
+    mockUseRouteError.mockReturnValue(new Error('Something broke'));
+
+    render(<ErrorPage />);
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    expect(screen.getByText('Something broke')).toBeTruthy();
+  });
+
+  it('should display fallback message for non-Error objects', () => {
+    mockUseRouteError.mockReturnValue({ status: 404 });
+
+    render(<ErrorPage />);
+
+    expect(screen.getByText('An unexpected error occurred.')).toBeTruthy();
+  });
+
+  it('should have a link to home page', () => {
+    mockUseRouteError.mockReturnValue(new Error('test'));
+
+    render(<ErrorPage />);
+
+    const link = screen.getByText('Go to Home');
+    expect(link).toBeTruthy();
+    expect(link.closest('a')?.getAttribute('href')).toBe('/');
+  });
+});

--- a/src/pages/NotFoundPage.test.tsx
+++ b/src/pages/NotFoundPage.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import NotFoundPage from './NotFoundPage';
+
+vi.mock('react-router', () => ({
+  Link: ({ to, children, className }: { to: string; children: React.ReactNode; className?: string }) => (
+    <a href={to} className={className}>{children}</a>
+  ),
+}));
+
+describe('NotFoundPage', () => {
+  it('should display "Page Not Found" title', () => {
+    render(<NotFoundPage />);
+    expect(screen.getByText('Page Not Found')).toBeTruthy();
+  });
+
+  it('should have a link to home page', () => {
+    render(<NotFoundPage />);
+
+    const link = screen.getByText('Go to Home');
+    expect(link).toBeTruthy();
+    expect(link.closest('a')?.getAttribute('href')).toBe('/');
+  });
+});

--- a/src/services/fileHistory.test.ts
+++ b/src/services/fileHistory.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getFileHistory,
+  addFileToHistory,
+  removeFileFromHistory,
+  clearFileHistory,
+} from './fileHistory';
+import { storage } from './storage';
+
+vi.mock('./storage', () => ({
+  storage: {
+    getJSON: vi.fn(),
+    setJSON: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+const mockedStorage = vi.mocked(storage);
+
+describe('fileHistory', () => {
+  const testConfig = { storageKey: 'test-history', maxItems: 3 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedStorage.getJSON.mockResolvedValue(null);
+    mockedStorage.setJSON.mockResolvedValue(undefined);
+    mockedStorage.removeItem.mockResolvedValue(undefined);
+  });
+
+  describe('getFileHistory', () => {
+    it('should return empty array when no history', async () => {
+      const result = await getFileHistory(testConfig);
+      expect(result).toEqual([]);
+    });
+
+    it('should return items sorted by date (newest first)', async () => {
+      const items = [
+        { id: '1', name: 'old.md', selectedAt: '2025-01-01T00:00:00Z', source: 'google-drive' as const },
+        { id: '2', name: 'new.md', selectedAt: '2025-06-01T00:00:00Z', source: 'google-drive' as const },
+        { id: '3', name: 'mid.md', selectedAt: '2025-03-01T00:00:00Z', source: 'local' as const },
+      ];
+      mockedStorage.getJSON.mockResolvedValueOnce(items);
+
+      const result = await getFileHistory(testConfig);
+      expect(result[0].id).toBe('2');
+      expect(result[1].id).toBe('3');
+      expect(result[2].id).toBe('1');
+    });
+
+    it('should return empty array on storage error', async () => {
+      mockedStorage.getJSON.mockRejectedValueOnce(new Error('storage error'));
+      const result = await getFileHistory(testConfig);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('addFileToHistory', () => {
+    it('should add a new file to history', async () => {
+      mockedStorage.getJSON.mockResolvedValueOnce([]);
+
+      await addFileToHistory({ id: 'f1', name: 'test.md' }, testConfig);
+
+      expect(mockedStorage.setJSON).toHaveBeenCalledWith(
+        'test-history',
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'f1', name: 'test.md', source: 'google-drive' }),
+        ])
+      );
+    });
+
+    it('should deduplicate existing file (move to top)', async () => {
+      const existing = [
+        { id: 'f1', name: 'old.md', selectedAt: '2025-01-01T00:00:00Z', source: 'google-drive' },
+        { id: 'f2', name: 'other.md', selectedAt: '2025-02-01T00:00:00Z', source: 'google-drive' },
+      ];
+      mockedStorage.getJSON.mockResolvedValueOnce(existing);
+
+      await addFileToHistory({ id: 'f1', name: 'old.md' }, testConfig);
+
+      const savedHistory = mockedStorage.setJSON.mock.calls[0][1] as Array<{ id: string }>;
+      expect(savedHistory[0].id).toBe('f1');
+      expect(savedHistory).toHaveLength(2);
+    });
+
+    it('should trim history to maxItems', async () => {
+      const existing = [
+        { id: 'f1', name: 'a.md', selectedAt: '2025-03-01T00:00:00Z', source: 'google-drive' },
+        { id: 'f2', name: 'b.md', selectedAt: '2025-02-01T00:00:00Z', source: 'google-drive' },
+        { id: 'f3', name: 'c.md', selectedAt: '2025-01-01T00:00:00Z', source: 'google-drive' },
+      ];
+      mockedStorage.getJSON.mockResolvedValueOnce(existing);
+
+      await addFileToHistory({ id: 'f4', name: 'd.md' }, testConfig);
+
+      const savedHistory = mockedStorage.setJSON.mock.calls[0][1] as Array<{ id: string }>;
+      expect(savedHistory).toHaveLength(3); // maxItems = 3
+      expect(savedHistory[0].id).toBe('f4');
+      expect(savedHistory.find((h) => h.id === 'f3')).toBeUndefined(); // oldest trimmed
+    });
+
+    it('should use provided source', async () => {
+      mockedStorage.getJSON.mockResolvedValueOnce([]);
+
+      await addFileToHistory({ id: 'f1', name: 'local.md', source: 'local' }, testConfig);
+
+      const savedHistory = mockedStorage.setJSON.mock.calls[0][1] as Array<{ source: string }>;
+      expect(savedHistory[0].source).toBe('local');
+    });
+
+    it('should not throw on storage error', async () => {
+      mockedStorage.getJSON.mockRejectedValueOnce(new Error('fail'));
+      await expect(
+        addFileToHistory({ id: 'f1', name: 'test.md' }, testConfig)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('removeFileFromHistory', () => {
+    it('should remove a specific file', async () => {
+      const existing = [
+        { id: 'f1', name: 'a.md', selectedAt: '2025-01-01T00:00:00Z', source: 'google-drive' },
+        { id: 'f2', name: 'b.md', selectedAt: '2025-02-01T00:00:00Z', source: 'google-drive' },
+      ];
+      mockedStorage.getJSON.mockResolvedValueOnce(existing);
+
+      await removeFileFromHistory('f1', testConfig);
+
+      const savedHistory = mockedStorage.setJSON.mock.calls[0][1] as Array<{ id: string }>;
+      expect(savedHistory).toHaveLength(1);
+      expect(savedHistory[0].id).toBe('f2');
+    });
+
+    it('should not throw on storage error', async () => {
+      mockedStorage.getJSON.mockRejectedValueOnce(new Error('fail'));
+      await expect(
+        removeFileFromHistory('f1', testConfig)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearFileHistory', () => {
+    it('should call removeItem with correct key', async () => {
+      await clearFileHistory(testConfig);
+      expect(mockedStorage.removeItem).toHaveBeenCalledWith('test-history');
+    });
+
+    it('should not throw on storage error', async () => {
+      mockedStorage.removeItem.mockRejectedValueOnce(new Error('fail'));
+      await expect(clearFileHistory(testConfig)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { storage } from './storage';
+
+function createLocalStorageMock() {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  };
+}
+
+describe('storage', () => {
+  let storageMock: ReturnType<typeof createLocalStorageMock>;
+
+  beforeEach(() => {
+    storageMock = createLocalStorageMock();
+    Object.defineProperty(window, 'localStorage', {
+      value: storageMock,
+      writable: true,
+    });
+  });
+
+  describe('setItem', () => {
+    it('should store a value', async () => {
+      await storage.setItem('key1', 'value1');
+      expect(storageMock.setItem).toHaveBeenCalledWith('key1', 'value1');
+    });
+
+    it('should throw on localStorage error', async () => {
+      storageMock.setItem.mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      await expect(storage.setItem('key1', 'value1')).rejects.toThrow(
+        'QuotaExceededError'
+      );
+    });
+  });
+
+  describe('getItem', () => {
+    it('should return stored value', async () => {
+      storageMock.setItem('key1', 'value1');
+      const result = await storage.getItem('key1');
+      expect(result).toBe('value1');
+    });
+
+    it('should return null for missing key', async () => {
+      const result = await storage.getItem('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('should return null on localStorage error', async () => {
+      storageMock.getItem.mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+      const result = await storage.getItem('key1');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('removeItem', () => {
+    it('should remove a key', async () => {
+      await storage.removeItem('key1');
+      expect(storageMock.removeItem).toHaveBeenCalledWith('key1');
+    });
+
+    it('should not throw on localStorage error', async () => {
+      storageMock.removeItem.mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+      await expect(storage.removeItem('key1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('multiRemove', () => {
+    it('should remove multiple keys', async () => {
+      await storage.multiRemove(['a', 'b', 'c']);
+      expect(storageMock.removeItem).toHaveBeenCalledWith('a');
+      expect(storageMock.removeItem).toHaveBeenCalledWith('b');
+      expect(storageMock.removeItem).toHaveBeenCalledWith('c');
+    });
+
+    it('should continue removing even if one key fails', async () => {
+      let callCount = 0;
+      storageMock.removeItem.mockImplementation(() => {
+        callCount++;
+        if (callCount === 2) throw new Error('fail');
+      });
+      await storage.multiRemove(['a', 'b', 'c']);
+      expect(storageMock.removeItem).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('getAllKeys', () => {
+    it('should return all keys from localStorage', async () => {
+      // getAllKeys calls Object.keys(localStorage), so we need a mock
+      // whose own enumerable keys are the stored data keys
+      const keysStorageMock = Object.create(null) as Record<string, unknown>;
+      keysStorageMock['k1'] = 'v1';
+      keysStorageMock['k2'] = 'v2';
+      Object.defineProperty(window, 'localStorage', {
+        value: keysStorageMock,
+        writable: true,
+        configurable: true,
+      });
+      const keys = await storage.getAllKeys();
+      expect(keys).toEqual(expect.arrayContaining(['k1', 'k2']));
+      expect(keys).toHaveLength(2);
+      // Restore mock
+      Object.defineProperty(window, 'localStorage', {
+        value: storageMock,
+        writable: true,
+        configurable: true,
+      });
+    });
+  });
+
+  describe('setJSON', () => {
+    it('should store JSON-serialized value', async () => {
+      await storage.setJSON('data', { foo: 'bar', count: 42 });
+      expect(storageMock.setItem).toHaveBeenCalledWith(
+        'data',
+        JSON.stringify({ foo: 'bar', count: 42 })
+      );
+    });
+
+    it('should handle arrays', async () => {
+      await storage.setJSON('arr', [1, 2, 3]);
+      expect(storageMock.setItem).toHaveBeenCalledWith('arr', '[1,2,3]');
+    });
+  });
+
+  describe('getJSON', () => {
+    it('should return parsed JSON', async () => {
+      storageMock.setItem('data', JSON.stringify({ foo: 'bar' }));
+      const result = await storage.getJSON<{ foo: string }>('data');
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should return null for missing key', async () => {
+      const result = await storage.getJSON('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for invalid JSON', async () => {
+      storageMock.setItem('bad', '{invalid json}');
+      const result = await storage.getJSON('bad');
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- カバレッジ 0% だった8ファイルのうち7ファイルにテストを新規作成
- Lines カバレッジ: **67.7% → 79.7%** (目標 75%+ 達成)
- 全 448 テスト通過

## 追加テストファイル
| ファイル | カバレッジ改善 |
|---|---|
| `src/services/storage.test.ts` | 31% → 93% |
| `src/services/fileHistory.test.ts` | 0% → 93% |
| `src/hooks/useMarkdownEditor.test.ts` | 0% → new |
| `src/hooks/useAddToHomeScreen.test.ts` | 0% → new |
| `src/pages/ErrorPage.test.tsx` | 0% → 100% |
| `src/pages/NotFoundPage.test.tsx` | 0% → 100% |
| `src/components/markdown/MarkdownRenderer.test.tsx` | 0% → new |

## スキップしたファイル
- `CodeMirrorEditor.tsx`: EditorView モック化が困難で ROI が低い
- `HomePage.tsx` (52%): 既存テストあり、残りは複雑な OAuth フロー

## Test plan
- [x] `bunx vitest run --coverage` で全 448 テスト通過
- [x] Lines カバレッジ 79.7% 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)