### PR TITLE
ci: GitHub Actions による手動プレビューデプロイを追加

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,88 @@
+name: Preview Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or PR number to deploy'
+        required: false
+        default: ''
+  issue_comment:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # workflow_dispatch は常に実行、issue_comment は PR に [preview] コメント時のみ
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request && contains(github.event.comment.body, '[preview]'))
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Resolve ref
+        id: ref
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+              core.setOutput('ref', pr.data.head.ref);
+              core.setOutput('pr_number', context.issue.number);
+            } else {
+              const input = '${{ github.event.inputs.ref }}';
+              if (input && /^\d+$/.test(input)) {
+                const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: parseInt(input),
+                });
+                core.setOutput('ref', pr.data.head.ref);
+                core.setOutput('pr_number', input);
+              } else {
+                core.setOutput('ref', input || context.ref);
+                core.setOutput('pr_number', '');
+              }
+            }
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - name: Install Vercel CLI
+        run: bun add -g vercel
+
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy
+        id: deploy
+        run: |
+          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: steps.ref.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.ref.outputs.pr_number }},
+              body: `🚀 Preview deployed: ${{ steps.deploy.outputs.url }}`
+            });


### PR DESCRIPTION
## Summary
- PRに `[preview]` とコメント or Actions タブから手動実行で Vercel プレビューデプロイが実行可能に
- デプロイ完了後、PR にプレビュー URL がコメントされる
- main への自動デプロイには影響なし

## 必要なセットアップ
GitHub Secrets に `VERCEL_TOKEN` を追加

## Test plan
- [ ] PRに `[preview]` コメント → ワークフローが起動することを確認
- [ ] デプロイ完了後、PR にプレビューURLがコメントされることを確認
- [ ] Actions タブから手動実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)