### PR TITLE
fix: ViewerPage のローディングスピナー位置を修正

### DIFF
--- a/src/pages/ViewerPage.module.css
+++ b/src/pages/ViewerPage.module.css
@@ -1,6 +1,8 @@
 /* ViewerPage styles */
 
 .container {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   overflow-y: auto;
   background-color: var(--color-bg-primary);


### PR DESCRIPTION
## Summary
- ViewerPage の `.container` に `display: flex; flex-direction: column` を追加
- ローディングスピナーがヘッダーにかぶらず、残りスペースの縦中央に表示されるように修正

## Test plan
- [x] ViewerPage テスト 70件 通過
- [x] ファイル読み込み時のスピナーがヘッダー下の中央に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)