### PR TITLE
feat: Drive「アプリで開く」用の /open ルーティング追加

### DIFF
--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -116,7 +116,7 @@ describe('useGoogleAuth', () => {
     storageMock = createLocalStorageMock();
     Object.defineProperty(window, 'localStorage', { value: storageMock, writable: true });
     // Pre-set scope version so token restoration doesn't get cleared
-    storageMock.setItem('googleDriveScopeVersion', '2');
+    storageMock.setItem('googleDriveScopeVersion', '3');
     setupEnvVars();
     setupGoogleApis();
     stubScriptLoading();
@@ -147,7 +147,7 @@ describe('useGoogleAuth', () => {
     it('should restore valid token from storage', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'stored-token-value';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -163,7 +163,7 @@ describe('useGoogleAuth', () => {
     it('should not restore expired token', async () => {
       const pastExpiry = String(Date.now() - 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'old-token';
         if (key === 'googleDriveTokenExpiry') return pastExpiry;
         return null;
@@ -179,7 +179,7 @@ describe('useGoogleAuth', () => {
     it('should not restore token expiring within 5 minutes', async () => {
       const nearExpiry = String(Date.now() + 3 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'near-expired-token';
         if (key === 'googleDriveTokenExpiry') return nearExpiry;
         return null;
@@ -209,7 +209,7 @@ describe('useGoogleAuth', () => {
     it('should clear results for empty query', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -229,7 +229,7 @@ describe('useGoogleAuth', () => {
     it('should return search results when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -252,7 +252,7 @@ describe('useGoogleAuth', () => {
 
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -275,7 +275,7 @@ describe('useGoogleAuth', () => {
     it('should load recent files when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -311,7 +311,7 @@ describe('useGoogleAuth', () => {
     it('should fetch file content when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -348,7 +348,7 @@ describe('useGoogleAuth', () => {
 
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -371,7 +371,7 @@ describe('useGoogleAuth', () => {
     it('should clear all state on logout', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -397,7 +397,7 @@ describe('useGoogleAuth', () => {
     it('should revoke token via Google API', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -419,7 +419,7 @@ describe('useGoogleAuth', () => {
     it('should clear stored token from localStorage', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -471,7 +471,7 @@ describe('useGoogleAuth', () => {
     function authenticateHook() {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '2';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;

--- a/src/hooks/useGoogleAuth.ts
+++ b/src/hooks/useGoogleAuth.ts
@@ -19,11 +19,11 @@ const API_KEY = import.meta.env.VITE_GOOGLE_API_KEY || '';
 const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
 const APP_ID = import.meta.env.VITE_GOOGLE_APP_ID || '';
 
-// Google API のスコープ（Picker で選択したファイルのみアクセス可能）
-const SCOPES = 'https://www.googleapis.com/auth/drive.file';
+// Google API のスコープ（Picker で選択したファイルのみアクセス可能 + Drive「アプリで開く」対応）
+const SCOPES = 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.install';
 
 // スコープバージョン（スコープ変更時にインクリメントして旧トークンを無効化）
-const SCOPE_VERSION = '2'; // v1: drive.readonly → v2: drive.file
+const SCOPE_VERSION = '3'; // v1: drive.readonly → v2: drive.file → v3: +drive.install
 
 // ストレージのキー
 const TOKEN_KEY = 'googleDriveAccessToken';

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -201,6 +201,17 @@ export const en = {
     footer: 'Built with Vite and React',
   },
 
+  // Open (Drive "Open with")
+  open: {
+    loading: 'Opening file...',
+    signIn: 'Sign in to open this file',
+    signInButton: 'Sign in with Google',
+    error: 'Failed to open file',
+    invalidState: 'Invalid request from Google Drive',
+    retry: 'Retry',
+    backToHome: 'Back to Home',
+  },
+
   // Common
   common: {
     justNow: 'Just now',
@@ -498,6 +509,15 @@ export type Translations = {
     viewTerms: string;
     viewPrivacy: string;
     footer: string;
+  };
+  open: {
+    loading: string;
+    signIn: string;
+    signInButton: string;
+    error: string;
+    invalidState: string;
+    retry: string;
+    backToHome: string;
   };
   common: {
     justNow: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -203,6 +203,17 @@ export const ja: Translations = {
     footer: 'Vite + React で構築',
   },
 
+  // Open (Drive「アプリで開く」)
+  open: {
+    loading: 'ファイルを開いています...',
+    signIn: 'このファイルを開くにはサインインしてください',
+    signInButton: 'Google でサインイン',
+    error: 'ファイルを開けませんでした',
+    invalidState: 'Google Drive からのリクエストが無効です',
+    retry: '再試行',
+    backToHome: 'ホームに戻る',
+  },
+
   // Common
   common: {
     justNow: 'たった今',

--- a/src/pages/OpenPage.module.css
+++ b/src/pages/OpenPage.module.css
@@ -1,0 +1,119 @@
+.container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-bg-secondary);
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xl);
+  gap: var(--spacing-lg);
+}
+
+/* Loading */
+.spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.loadingText {
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+}
+
+/* Auth Prompt */
+.authPrompt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-lg);
+}
+
+.authText {
+  font-size: var(--font-size-base);
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.authButton {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--border-radius-md);
+  background-color: #ffffff;
+  border: 1px solid #dadce0;
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: #3c4043;
+  font-family: 'Roboto', sans-serif;
+}
+
+.authButton:hover {
+  background-color: #f8f9fa;
+}
+
+/* Error */
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.errorText {
+  font-size: var(--font-size-base);
+  color: var(--color-error, #d93025);
+  text-align: center;
+}
+
+.actions {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.retryButton {
+  padding: var(--spacing-xs) var(--spacing-lg);
+  border-radius: var(--border-radius-md);
+  background-color: var(--color-accent);
+  color: #ffffff;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+}
+
+.retryButton:hover {
+  opacity: 0.9;
+}
+
+.homeLink {
+  padding: var(--spacing-xs) var(--spacing-lg);
+  border-radius: var(--border-radius-md);
+  background: none;
+  border: 1px solid var(--color-border);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+}
+
+.homeLink:hover {
+  background-color: var(--color-bg-tertiary);
+}

--- a/src/pages/OpenPage.test.tsx
+++ b/src/pages/OpenPage.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { ThemeProvider } from '../contexts/ThemeContext';
+
+// ---------- mocks ----------
+
+const mockNavigate = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [mockSearchParams],
+  Link: ({ to, children, className }: any) => (
+    <a href={to} className={className}>{children}</a>
+  ),
+}));
+
+vi.mock('../components/ui', () => ({
+  GoogleLogo: ({ size }: any) => <span data-testid="google-logo" />,
+}));
+
+const mockAuthenticate = vi.fn();
+const mockFetchFileInfo = vi.fn();
+
+const mockAuthState = {
+  isAuthenticated: false,
+  isLoading: false,
+  accessToken: null as string | null,
+  authenticate: mockAuthenticate,
+};
+
+vi.mock('../hooks', () => ({
+  useGoogleAuth: () => mockAuthState,
+  useLanguage: () => ({
+    t: {
+      open: {
+        loading: 'Opening file...',
+        signIn: 'Sign in to open this file',
+        signInButton: 'Sign in with Google',
+        error: 'Failed to open file',
+        invalidState: 'Invalid request from Google Drive',
+        retry: 'Retry',
+        backToHome: 'Back to Home',
+      },
+    },
+    language: 'en',
+    setLanguage: vi.fn(),
+  }),
+}));
+
+vi.mock('../services/googleDrive', () => ({
+  fetchFileInfo: (...args: any[]) => mockFetchFileInfo(...args),
+}));
+
+// ---------- helpers ----------
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+function setSearchParams(params: Record<string, string>) {
+  mockSearchParams = new URLSearchParams(params);
+}
+
+beforeEach(() => {
+  cleanup();
+  mockNavigate.mockClear();
+  mockAuthenticate.mockClear();
+  mockFetchFileInfo.mockClear();
+
+  Object.assign(mockAuthState, {
+    isAuthenticated: false,
+    isLoading: false,
+    accessToken: null,
+    authenticate: mockAuthenticate,
+  });
+
+  mockSearchParams = new URLSearchParams();
+
+  window.matchMedia = vi.fn(() => ({
+    matches: true,
+    media: '',
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+});
+
+// ---------- tests ----------
+
+import OpenPage from './OpenPage';
+
+describe('OpenPage', () => {
+  it('shows invalid state error when no state param', () => {
+    renderWithProviders(<OpenPage />);
+    expect(screen.getByText('Invalid request from Google Drive')).toBeTruthy();
+    expect(screen.getByText('Back to Home')).toBeTruthy();
+  });
+
+  it('shows invalid state error when state is invalid JSON', () => {
+    setSearchParams({ state: 'not-json' });
+    renderWithProviders(<OpenPage />);
+    expect(screen.getByText('Invalid request from Google Drive')).toBeTruthy();
+  });
+
+  it('shows invalid state error when state has no ids', () => {
+    setSearchParams({ state: JSON.stringify({ action: 'open', ids: [], userId: '123' }) });
+    renderWithProviders(<OpenPage />);
+    expect(screen.getByText('Invalid request from Google Drive')).toBeTruthy();
+  });
+
+  it('shows sign-in prompt when not authenticated with valid state', () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-123'], userId: 'user-1' }),
+    });
+    renderWithProviders(<OpenPage />);
+    expect(screen.getByText('Sign in to open this file')).toBeTruthy();
+    expect(screen.getByText('Sign in with Google')).toBeTruthy();
+  });
+
+  it('calls authenticate when sign-in button is clicked', () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-123'], userId: 'user-1' }),
+    });
+    renderWithProviders(<OpenPage />);
+    const signInButton = screen.getByText('Sign in with Google').closest('button')!;
+    fireEvent.click(signInButton);
+    expect(mockAuthenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows loading when auth is loading', () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-123'], userId: 'user-1' }),
+    });
+    mockAuthState.isLoading = true;
+    renderWithProviders(<OpenPage />);
+    expect(screen.getByText('Opening file...')).toBeTruthy();
+  });
+
+  it('calls fetchFileInfo and navigates when authenticated', async () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-123'], userId: 'user-1' }),
+    });
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.accessToken = 'test-token';
+    mockFetchFileInfo.mockResolvedValue({ id: 'file-123', name: 'readme.md' });
+
+    renderWithProviders(<OpenPage />);
+
+    await waitFor(() => {
+      expect(mockFetchFileInfo).toHaveBeenCalledWith('test-token', 'file-123');
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/viewer?id=file-123&name=readme.md&source=google-drive',
+        { replace: true }
+      );
+    });
+  });
+
+  it('uses fileId as fallback name when fetchFileInfo returns null', async () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-456'], userId: 'user-1' }),
+    });
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.accessToken = 'test-token';
+    mockFetchFileInfo.mockResolvedValue(null);
+
+    renderWithProviders(<OpenPage />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/viewer?id=file-456&name=file-456.md&source=google-drive',
+        { replace: true }
+      );
+    });
+  });
+
+  it('shows error when fetchFileInfo throws', async () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-err'], userId: 'user-1' }),
+    });
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.accessToken = 'test-token';
+    mockFetchFileInfo.mockRejectedValue(new Error('Network error'));
+
+    renderWithProviders(<OpenPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to open file')).toBeTruthy();
+    });
+    expect(screen.getByText('Retry')).toBeTruthy();
+    expect(screen.getByText('Back to Home')).toBeTruthy();
+  });
+
+  it('retries when retry button is clicked after error', async () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-retry'], userId: 'user-1' }),
+    });
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.accessToken = 'test-token';
+    mockFetchFileInfo.mockRejectedValueOnce(new Error('fail'));
+
+    renderWithProviders(<OpenPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to open file')).toBeTruthy();
+    });
+
+    mockFetchFileInfo.mockResolvedValueOnce({ id: 'file-retry', name: 'test.md' });
+    fireEvent.click(screen.getByText('Retry'));
+
+    await waitFor(() => {
+      expect(mockFetchFileInfo).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('has a link back to home in error state', async () => {
+    setSearchParams({
+      state: JSON.stringify({ action: 'open', ids: ['file-err'], userId: 'user-1' }),
+    });
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.accessToken = 'test-token';
+    mockFetchFileInfo.mockRejectedValue(new Error('fail'));
+
+    renderWithProviders(<OpenPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Back to Home')).toBeTruthy();
+    });
+    const link = screen.getByText('Back to Home');
+    expect(link.closest('a')?.getAttribute('href')).toBe('/');
+  });
+});

--- a/src/pages/OpenPage.tsx
+++ b/src/pages/OpenPage.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useSearchParams, useNavigate, Link } from 'react-router';
+import { useGoogleAuth, useLanguage } from '../hooks';
+import { fetchFileInfo } from '../services/googleDrive';
+import { GoogleLogo } from '../components/ui';
+import styles from './OpenPage.module.css';
+
+interface DriveOpenState {
+  action: 'open' | 'create';
+  ids: string[];
+  resourceKeys?: Record<string, string>;
+  userId: string;
+}
+
+function parseDriveState(raw: string | null): DriveOpenState | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      Array.isArray(parsed.ids) &&
+      parsed.ids.length > 0
+    ) {
+      return parsed as DriveOpenState;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export default function OpenPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading: isAuthLoading, accessToken, authenticate } = useGoogleAuth();
+  const { t } = useLanguage();
+
+  const [error, setError] = useState<string | null>(null);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  const stateParam = searchParams.get('state');
+  const driveState = parseDriveState(stateParam);
+  const fileId = driveState?.ids[0] ?? null;
+
+  const openFile = useCallback(async () => {
+    if (!fileId || !accessToken) return;
+
+    setIsRedirecting(true);
+    setError(null);
+
+    try {
+      const info = await fetchFileInfo(accessToken, fileId);
+      const name = info?.name ?? `${fileId}.md`;
+      navigate(`/viewer?id=${encodeURIComponent(fileId)}&name=${encodeURIComponent(name)}&source=google-drive`, {
+        replace: true,
+      });
+    } catch {
+      setError(t.open.error);
+      setIsRedirecting(false);
+    }
+  }, [fileId, accessToken, navigate, t.open.error]);
+
+  // 認証済みでファイル ID がある場合、自動的にファイルを開く
+  useEffect(() => {
+    if (isAuthenticated && fileId && accessToken && !isRedirecting && !error) {
+      openFile();
+    }
+  }, [isAuthenticated, fileId, accessToken, isRedirecting, error, openFile]);
+
+  // state パラメータが無効な場合
+  if (!driveState) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.content}>
+          <div className={styles.errorContainer}>
+            <p className={styles.errorText}>{t.open.invalidState}</p>
+            <div className={styles.actions}>
+              <Link to="/" className={styles.homeLink}>
+                {t.open.backToHome}
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 認証ロード中またはリダイレクト中
+  if (isAuthLoading || isRedirecting) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.content}>
+          <div className={styles.spinner} />
+          <p className={styles.loadingText}>{t.open.loading}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // エラー表示
+  if (error) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.content}>
+          <div className={styles.errorContainer}>
+            <p className={styles.errorText}>{error}</p>
+            <div className={styles.actions}>
+              <button
+                className={styles.retryButton}
+                onClick={() => {
+                  setError(null);
+                  openFile();
+                }}
+              >
+                {t.open.retry}
+              </button>
+              <Link to="/" className={styles.homeLink}>
+                {t.open.backToHome}
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 未認証: サインインプロンプト
+  if (!isAuthenticated) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.content}>
+          <div className={styles.authPrompt}>
+            <p className={styles.authText}>{t.open.signIn}</p>
+            <button className={styles.authButton} onClick={authenticate}>
+              <GoogleLogo size={18} />
+              {t.open.signInButton}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 認証済み: ローディング（useEffect で自動遷移）
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <div className={styles.spinner} />
+        <p className={styles.loadingText}>{t.open.loading}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,6 +9,7 @@ import PrivacyPage from './pages/PrivacyPage';
 import TermsPage from './pages/TermsPage';
 import LicensePage from './pages/LicensePage';
 import ThirdPartyLicensesPage from './pages/ThirdPartyLicensesPage';
+import OpenPage from './pages/OpenPage';
 
 export const router = createBrowserRouter([
   {
@@ -18,6 +19,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: 'viewer', element: <ViewerPage /> },
+      { path: 'open', element: <OpenPage /> },
       { path: 'about', element: <AboutPage /> },
       { path: 'privacy', element: <PrivacyPage /> },
       { path: 'terms', element: <TermsPage /> },


### PR DESCRIPTION
## Summary
- Google Drive の「アプリで開く」メニューから MarkDrive を起動する `/open` ルートを新設
- `state` クエリパラメータを JSON パースし、認証チェック後に `fetchFileInfo` でファイル名を取得して `/viewer` へリダイレクト
- OAuth スコープに `drive.install` を追加（SCOPE_VERSION v2→v3 で旧トークン自動クリア）
- EN/JA の翻訳を追加、OpenPage のテスト 11 件を追加

## Changes
| ファイル | 変更内容 |
|---|---|
| `src/pages/OpenPage.tsx` | 新規: state パース → 認証 → fetchFileInfo → /viewer リダイレクト |
| `src/pages/OpenPage.module.css` | 新規: ローディング・認証プロンプト・エラー表示のスタイル |
| `src/pages/OpenPage.test.tsx` | 新規: 11 テスト |
| `src/router.tsx` | `/open` ルート追加 |
| `src/hooks/useGoogleAuth.ts` | SCOPES に drive.install 追加、SCOPE_VERSION '3' |
| `src/hooks/useGoogleAuth.test.ts` | スコープバージョン値を '3' に更新 |
| `src/i18n/locales/en.ts` | `open` セクション追加（翻訳 + 型定義） |
| `src/i18n/locales/ja.ts` | `open` セクション追加 |

## Test plan
- [x] `bunx tsc --noEmit` 型チェック通過
- [x] `bun run test` 全 455 テスト通過
- [x] `/open?state={"action":"open","ids":["FILE_ID"],"userId":"123"}` に手動アクセスして動作確認
- [x] 未認証時: サインイン画面 → ログイン後ファイル表示
- [x] 認証済み: 自動的に ViewerPage へ遷移
- [x] 不正な state: エラーメッセージ表示

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)