### PR TITLE
feat: Try Nowボタンでサンプルをログイン不要プレビュー

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -86,6 +86,7 @@ export const en = {
     or: 'or',
     openLocal: 'Open Local File',
     searchDrive: 'Search Google Drive',
+    tryNow: 'Try Now — Preview a Sample',
     learnMore: 'Learn more about MarkDrive',
     searchPlaceholder: 'Search Google Drive...',
     recentFiles: 'Recent Files',
@@ -425,6 +426,7 @@ export type Translations = {
     or: string;
     openLocal: string;
     searchDrive: string;
+    tryNow: string;
     learnMore: string;
     searchPlaceholder: string;
     recentFiles: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -88,6 +88,7 @@ export const ja: Translations = {
     or: 'または',
     openLocal: 'ローカルファイルを開く',
     searchDrive: 'Google Drive を検索',
+    tryNow: '今すぐ試す — サンプルをプレビュー',
     learnMore: 'MarkDriveについて詳しく',
     searchPlaceholder: 'Google Driveを検索...',
     recentFiles: '最近のファイル',

--- a/src/pages/HomePage.module.css
+++ b/src/pages/HomePage.module.css
@@ -629,6 +629,28 @@
   color: var(--color-accent);
 }
 
+/* Try Now Link */
+.tryNowLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-md);
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-accent);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  text-decoration: none;
+  transition: opacity 150ms ease;
+}
+
+.tryNowLink:hover {
+  text-decoration: underline;
+  opacity: 0.8;
+}
+
 /* Footer */
 .landingFooter {
   margin-top: 48px;

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -15,6 +15,7 @@ vi.mock('react-router', () => ({
 }));
 
 vi.mock('../../assets/images/icon.png', () => ({ default: 'icon.png' }));
+vi.mock('../../docs/markdrive-sample.md?raw', () => ({ default: '# Sample Markdown\n\nThis is a sample.' }));
 
 vi.mock('react-icons/io5', () => {
   const stub = (name: string) => (props: any) => <span data-testid={`icon-${name}`} {...props} />;
@@ -40,6 +41,7 @@ vi.mock('react-icons/io5', () => {
     IoLogOutOutline: stub('logout'),
     IoLogoGithub: stub('github'),
     IoSettingsOutline: stub('settings'),
+    IoPlayOutline: stub('play'),
   };
 });
 
@@ -103,6 +105,7 @@ vi.mock('../hooks', () => ({
         or: 'or',
         openLocal: 'Open Local File',
         searchDrive: 'Search Google Drive',
+        tryNow: 'Try Now — Preview a Sample',
         searchPlaceholder: 'Search files...',
         recentFiles: 'Recent Files',
         clear: 'Clear',
@@ -282,6 +285,26 @@ describe('HomePage (unauthenticated)', () => {
   it('renders how it works section title', () => {
     renderWithProviders(<HomePage />);
     expect(screen.getByText('How It Works')).toBeTruthy();
+  });
+
+  it('renders Try Now buttons', () => {
+    renderWithProviders(<HomePage />);
+    const tryNowButtons = screen.getAllByText('Try Now — Preview a Sample');
+    expect(tryNowButtons.length).toBe(2);
+  });
+
+  it('navigates to viewer with sample content on Try Now click', () => {
+    renderWithProviders(<HomePage />);
+    const tryNowButtons = screen.getAllByText('Try Now — Preview a Sample');
+    fireEvent.click(tryNowButtons[0]);
+    expect(mockNavigate).toHaveBeenCalledWith('/viewer', {
+      state: {
+        id: 'sample-markdrive',
+        name: 'markdrive-sample.md',
+        content: '# Sample Markdown\n\nThis is a sample.',
+        source: 'local',
+      },
+    });
   });
 });
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -22,6 +22,7 @@ import {
   IoDocumentOutline,
   IoLogoGithub,
   IoSettingsOutline,
+  IoPlayOutline,
 } from 'react-icons/io5';
 import { Button, LoadingSpinner, FAB, SettingsMenu, UserMenu, GoogleLogo } from '../components/ui';
 import { AddToHomeScreenBanner } from '../components/ui/AddToHomeScreenBanner';
@@ -29,6 +30,7 @@ import { useGoogleAuth, useTheme, useLanguage, usePickerSettings } from '../hook
 import { useFilePicker } from '../hooks';
 import { getFileHistory, clearFileHistory, addFileToHistory } from '../services';
 import type { FileHistoryItem } from '../types';
+import sampleMd from '../../docs/markdrive-sample.md?raw';
 import iconImage from '../../assets/images/icon.png';
 import styles from './HomePage.module.css';
 
@@ -69,6 +71,17 @@ export default function HomePage() {
     const history = await getFileHistory();
     setRecentFiles(history.filter((item) => item.source !== 'local'));
   };
+
+  const handleTryNow = useCallback(() => {
+    navigate('/viewer', {
+      state: {
+        id: 'sample-markdrive',
+        name: 'markdrive-sample.md',
+        content: sampleMd,
+        source: 'local',
+      },
+    });
+  }, [navigate]);
 
   const handleLocalFile = useCallback(async () => {
     const file = await openPicker();
@@ -279,6 +292,14 @@ export default function HomePage() {
                   >
                     {t.home.signIn}
                   </Button>
+                  <button
+                    className={styles.tryNowLink}
+                    onClick={handleTryNow}
+                    type="button"
+                  >
+                    <IoPlayOutline size={16} />
+                    <span>{t.home.tryNow}</span>
+                  </button>
                 </div>
 
                 {/* Right: Preview image with crossfade animation */}
@@ -481,6 +502,14 @@ export default function HomePage() {
                 >
                   {t.home.openLocal}
                 </Button>
+                <button
+                  className={styles.tryNowLink}
+                  onClick={handleTryNow}
+                  type="button"
+                >
+                  <IoPlayOutline size={16} />
+                  <span>{t.home.tryNow}</span>
+                </button>
               </div>
 
               {/* Section 8: Footer */}

--- a/src/types/raw.d.ts
+++ b/src/types/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md?raw' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- ランディングページ（Hero / Closing CTA）に「Try Now」ボタンを2箇所追加
- クリックすると `docs/markdrive-sample.md` を Vite の `?raw` import でバンドルし、`location.state` 経由で ViewerPage に遷移
- ログイン不要でサンプル Markdown（GFM、シンタックスハイライト、Mermaid、KaTeX）をプレビュー体験できる
- ファイル履歴には追加しない（サンプルのため）

## Test plan
- [x] `bunx tsc --noEmit` 型チェック通過
- [x] HomePage テスト 27 件全パス（Try Now ボタン表示 + navigate 呼び出しテスト含む）
- [x] 手動: ランディングで Try Now クリック → ViewerPage にサンプル Markdown が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)