### PR TITLE
feat: フッターに Google Drive™ 商標帰属テキストを追加

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -81,6 +81,7 @@ export const en = {
     footer: {
       builtWith: 'Built with Vite and React',
       viewOnGithub: 'View on GitHub',
+      trademark: 'Google Drive™ is a trademark of Google LLC.',
     },
     signIn: 'Sign in with Google',
     or: 'or',
@@ -425,6 +426,7 @@ export type Translations = {
     footer: {
       builtWith: string;
       viewOnGithub: string;
+      trademark: string;
     };
     signIn: string;
     or: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -83,6 +83,7 @@ export const ja: Translations = {
     footer: {
       builtWith: 'Vite + React で構築',
       viewOnGithub: 'GitHubで見る',
+      trademark: 'Google Drive™ is a trademark of Google LLC.',
     },
     signIn: 'Googleでサインイン',
     or: 'または',

--- a/src/pages/AboutPage.module.css
+++ b/src/pages/AboutPage.module.css
@@ -192,10 +192,18 @@
   padding-top: var(--spacing-xl);
   border-top: 1px solid var(--color-border);
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
 }
 
 .footerText {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+}
+
+.footerTrademark {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  opacity: 0.7;
 }

--- a/src/pages/AboutPage.test.tsx
+++ b/src/pages/AboutPage.test.tsx
@@ -35,6 +35,11 @@ vi.mock('react-icons/io5', () => ({
 }));
 
 const mockT = {
+  home: {
+    footer: {
+      trademark: 'Google Drive™ is a trademark of Google LLC.',
+    },
+  },
   about: {
     title: 'About',
     appName: 'MarkDrive',

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -141,6 +141,7 @@ export default function AboutPage() {
           {/* Footer */}
           <div className={styles.footer}>
             <span className={styles.footerText}>{t.about.footer}</span>
+            <span className={styles.footerTrademark}>{t.home.footer.trademark}</span>
           </div>
         </div>
       </div>

--- a/src/pages/HomePage.module.css
+++ b/src/pages/HomePage.module.css
@@ -724,6 +724,13 @@
   color: var(--color-text-muted);
 }
 
+.footerTrademark {
+  font-size: var(--font-size-xs);
+  text-align: center;
+  color: var(--color-text-muted);
+  opacity: 0.7;
+}
+
 /* Authenticated Content */
 .authenticatedContent {
   flex: 1;

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -144,6 +144,7 @@ vi.mock('../hooks', () => ({
         footer: {
           viewOnGithub: 'View on GitHub',
           builtWith: 'Built with React',
+          trademark: 'Google Drive™ is a trademark of Google LLC.',
         },
       },
       search: {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -547,6 +547,9 @@ export default function HomePage() {
                 <p className={styles.footerBuiltWith}>
                   {t.home.footer.builtWith}
                 </p>
+                <p className={styles.footerTrademark}>
+                  {t.home.footer.trademark}
+                </p>
               </div>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- HomePage・AboutPage のフッターに "Google Drive™ is a trademark of Google LLC." を追加
- i18n に `home.footer.trademark` キーを追加（en/ja 共通テキスト）
- 既存テストのモックも更新

## Test plan
- [x] `tsc --noEmit` 型チェック通過
- [x] HomePage フッターで商標テキストの表示を目視確認
- [x] AboutPage フッターで商標テキストの表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)