### PR TITLE
fix: 未使用のfb:app_idメタタグを削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:locale:alternate" content="ja_JP" />
-    <meta property="fb:app_id" content="61587948840978" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
## Summary
- 使用していない `fb:app_id` メタタグを `index.html` から削除

## Test plan
- [x] ビルドに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)