### PR TITLE
feat: /view?id=xxx 共有リンク対応

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,6 +113,8 @@ export const en = {
     saveFailed: 'Failed to save',
     unsavedChanges: 'You have unsaved changes. Discard them?',
     save: 'Save',
+    signInToView: 'Sign in to view this file',
+    signInButton: 'Sign in with Google',
     reauthRequired: 'Please sign out and sign in again to enable editing',
     linesCount: '{lines} lines',
     charsCount: '{chars} chars',
@@ -271,6 +273,8 @@ export const en = {
     googleDrive: 'Google Drive',
     local: 'Local File',
     exportPdf: 'Export PDF',
+    copyLink: 'Copy Link',
+    linkCopied: 'Copied!',
   },
 
   // Add to Home Screen
@@ -459,6 +463,8 @@ export type Translations = {
     saveFailed: string;
     unsavedChanges: string;
     save: string;
+    signInToView: string;
+    signInButton: string;
     reauthRequired: string;
     linesCount: string;
     charsCount: string;
@@ -581,6 +587,8 @@ export type Translations = {
     googleDrive: string;
     local: string;
     exportPdf: string;
+    copyLink: string;
+    linkCopied: string;
   };
   addToHomeScreen: {
     title: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -115,6 +115,8 @@ export const ja: Translations = {
     saveFailed: '保存に失敗しました',
     unsavedChanges: '未保存の変更があります。破棄しますか？',
     save: '保存',
+    signInToView: 'このファイルを表示するにはサインインしてください',
+    signInButton: 'Google でサインイン',
     reauthRequired: '編集を有効にするには、サインアウトして再度サインインしてください',
     linesCount: '{lines} 行',
     charsCount: '{chars} 文字',
@@ -273,6 +275,8 @@ export const ja: Translations = {
     googleDrive: 'Google Drive',
     local: 'ローカルファイル',
     exportPdf: 'PDF出力',
+    copyLink: 'リンクをコピー',
+    linkCopied: 'コピーしました！',
   },
 
   // Add to Home Screen

--- a/src/pages/ViewerPage.module.css
+++ b/src/pages/ViewerPage.module.css
@@ -470,3 +470,38 @@
 .pdfButton {
   width: 100%;
 }
+
+/* Auth Prompt (shared link sign-in) */
+.authPromptContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-lg);
+}
+
+.authPromptText {
+  font-size: var(--font-size-base);
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.authButton {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--border-radius-md);
+  background-color: #ffffff;
+  border: 1px solid #dadce0;
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: #3c4043;
+  font-family: 'Roboto', sans-serif;
+}
+
+.authButton:hover {
+  background-color: #f8f9fa;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -19,6 +19,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: 'viewer', element: <ViewerPage /> },
+      { path: 'view', element: <ViewerPage /> },
       { path: 'open', element: <OpenPage /> },
       { path: 'about', element: <AboutPage /> },
       { path: 'privacy', element: <PrivacyPage /> },


### PR DESCRIPTION
## Summary
- `/view?id=<fileId>` で Google Drive ファイルを直接開ける共有リンク機能を追加
- `source` パラメータ省略時は `google-drive` をデフォルトに設定し、`name` 未提供時は `fetchFileInfo` でファイル名を自動取得
- 未認証時に Google サインインプロンプトを表示（従来のエラーメッセージから改善）
- FileInfo ダイアログに「リンクをコピー」ボタンを追加（Google Drive ファイルのみ）

## Test plan
- [x] `/view?id=xxx` で未認証時にサインインプロンプトが表示される
- [x] サインイン後にファイルが正しく読み込まれる
- [x] `name` パラメータなしでもファイル名が自動取得される
- [x] FileInfo ダイアログの「リンクをコピー」でクリップボードにコピーされる
- [x] ローカルファイルでは「リンクをコピー」ボタンが表示されない
- [x] 既存の `/viewer` ルートが引き続き動作する
- [x] `bunx tsc --noEmit` 型チェック通過
- [ ] `bunx vitest run src/pages/ViewerPage.test.tsx` 全73テスト通過
- [ ] `bun run build` ビルド成功

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)