### PR TITLE
chore: SessionStart hook で gh CLI を自動インストール

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Web 環境以外では実行しない
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# gh CLI がインストール済みならスキップ
+if command -v gh &>/dev/null; then
+  exit 0
+fi
+
+# gh CLI をインストール
+GH_VERSION="2.87.0"
+GH_ARCHIVE="gh_${GH_VERSION}_linux_amd64.tar.gz"
+curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_ARCHIVE}" -o "/tmp/${GH_ARCHIVE}"
+tar -xzf "/tmp/${GH_ARCHIVE}" -C /tmp/
+cp "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+chmod +x /usr/local/bin/gh
+rm -rf "/tmp/${GH_ARCHIVE}" "/tmp/gh_${GH_VERSION}_linux_amd64"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "language": "ja",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
   "project": {
     "name": "md-viewer",
     "description": "Google Drive の Markdown ファイルをプレビューする Web アプリ",


### PR DESCRIPTION
## Summary
- Web 環境（Claude Code on the web）でセッション開始時に `gh` CLI を自動インストールする SessionStart hook を追加
- `.claude/settings.json` に hook を登録
- 既にインストール済みの場合はスキップする冪等な設計

## Test plan
- [x] hook スクリプトの実行で `gh` CLI が正常にインストールされることを確認
- [x] 冪等性（既にインストール済みならスキップ）を確認
- [x] `bun run test` でテストがパスすることを確認

https://claude.ai/code/session_01A5m5QzYMr1qSFQsND1jQvu