### PR TITLE
fix: Codecov の Missing Head Report を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,5 @@ jobs:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+          override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          override_branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- Codecov の `override_commit` と `override_branch` を設定し、PR の head commit SHA を明示的に渡すよう修正
- GitHub Actions の PR ワークフローでは merge commit がチェックアウトされるため、Codecov がレポートを正しく紐付けられず "Missing Head Report" エラーが発生していた

## Test plan
- [ ] この PR 自身の CI で Codecov ステータスチェックが表示されることを確認
- [ ] #151 を re-run して Codecov レポートが付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)