### PR TITLE
test: gapi.client 未定義時のカバレッジを追加

### DIFF
--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -668,6 +668,42 @@ describe('useGoogleAuth', () => {
       expect(pickerResult).toBeNull();
     });
 
+    it('should work without gapi.client (skip setToken)', async () => {
+      authenticateHook();
+
+      const mockBuilderInstance = {
+        addView: vi.fn().mockReturnThis(),
+        setOAuthToken: vi.fn().mockReturnThis(),
+        setDeveloperKey: vi.fn().mockReturnThis(),
+        setAppId: vi.fn().mockReturnThis(),
+        setOrigin: vi.fn().mockReturnThis(),
+        setSize: vi.fn().mockReturnThis(),
+        setCallback: vi.fn().mockReturnThis(),
+        enableFeature: vi.fn().mockReturnThis(),
+        build: vi.fn(() => ({ setVisible: vi.fn() })),
+      };
+
+      window.google.picker.PickerBuilder = function() { return mockBuilderInstance; } as any;
+      window.google.picker.DocsView = function() { return { setMimeTypes: vi.fn(), setMode: vi.fn(), setOwnedByMe: vi.fn() }; } as any;
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      // 初期化完了後に gapi.client を未定義にして falsy ブランチをテスト
+      const originalClient = window.gapi.client;
+      (window.gapi as any).client = undefined;
+
+      await act(async () => {
+        result.current.openDrivePicker();
+      });
+
+      // picker は正常にビルドされることを確認
+      expect(mockBuilderInstance.build).toHaveBeenCalled();
+
+      // 元に戻す
+      window.gapi.client = originalClient;
+    });
+
     it('should apply starred setting when enabled', async () => {
       authenticateHook();
 


### PR DESCRIPTION
## Summary
- PR #150 で追加された `if (window.gapi?.client)` の falsy ブランチのテストを追加
- Codecov patch coverage 50% → 100% を目指す修正

## Test plan
- [x] `bunx vitest run src/hooks/useGoogleAuth.test.ts` 全24テストパス
- [x] `gapi.client` が `undefined` の場合に `setToken` をスキップしつつ Picker が正常にビルドされることを検証

https://claude.ai/code/session_013B5XyY2cLmVi3JM7GqA2hP