### PR TITLE
chore: sitemap.xml に /support ページを追加

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -30,4 +30,9 @@
     <priority>0.4</priority>
     <changefreq>monthly</changefreq>
   </url>
+  <url>
+    <loc>https://mark-drive.com/support</loc>
+    <priority>0.5</priority>
+    <changefreq>monthly</changefreq>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- sitemap.xml に `/support` ページのエントリを追加（priority: 0.5, changefreq: monthly）

## Test plan
- [ ] `public/sitemap.xml` に `/support` の URL が正しく含まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)