### PR TITLE
chore: Codecov 設定を追加し Missing Head Report を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
 
@@ -32,3 +34,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
           override_branch: ${{ github.head_ref || github.ref_name }}
+          override_pr: ${{ github.event.pull_request.number }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary
- `codecov.yml` を追加（informational モードで coverage 可視化、merge はブロックしない）
- `fetch-depth: 0` で shallow clone による Missing Head Report を修正
- `override_pr` で PR 番号を明示的に Codecov に渡す

## Test plan
- [ ] CI の Codecov アップロードが成功すること
- [ ] PR に Codecov のカバレッジコメントが表示されること
- [ ] Codecov status check が informational（常に緑）であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)