### PR TITLE
feat: iOS PWA モードでのアプリ内 Drive ファイルブラウザ

### DIFF
--- a/src/components/ui/DriveFileBrowser.module.css
+++ b/src/components/ui/DriveFileBrowser.module.css
@@ -1,0 +1,192 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-primary, rgba(0, 0, 0, 0.6));
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: fadeIn 200ms ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  width: 90%;
+  max-width: 480px;
+  max-height: 80vh;
+  background: var(--color-bg-secondary, #1a1a2e);
+  border-radius: var(--border-radius-lg, 16px);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary, #fff);
+  margin: 0;
+}
+
+.closeButton {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.7));
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.closeButton:hover {
+  color: var(--color-text-primary, #fff);
+}
+
+.searchWrapper {
+  padding: 12px 20px;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.2));
+  border-radius: var(--border-radius-md, 8px);
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.05));
+  color: var(--color-text-primary, #fff);
+  font-size: 15px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.searchInput::placeholder {
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.4));
+}
+
+.searchInput:focus {
+  border-color: var(--color-accent, #4285f4);
+}
+
+.fileList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 20px 20px;
+}
+
+.sectionLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.5));
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.fileItem {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  border-radius: var(--border-radius-md, 8px);
+  margin-bottom: 6px;
+  gap: 12px;
+  background: var(--color-bg-card, rgba(255, 255, 255, 0.03));
+  cursor: pointer;
+  transition: opacity 150ms ease;
+}
+
+.fileItem:hover {
+  opacity: 0.7;
+}
+
+.fileIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--border-radius-sm, 6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-accent-muted, rgba(66, 133, 244, 0.15));
+  color: var(--color-accent, #4285f4);
+  flex-shrink: 0;
+}
+
+.fileName {
+  flex: 1;
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--color-text-primary, #fff);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.chevron {
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.4));
+  flex-shrink: 0;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 32px 16px;
+}
+
+.emptyMessage {
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 15px;
+  margin: 0 0 8px;
+}
+
+.emptyHint {
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.4));
+  font-size: 13px;
+  margin: 0;
+}
+
+.loadingState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 15px;
+  gap: 8px;
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--color-border, rgba(255, 255, 255, 0.2));
+  border-top-color: var(--color-text-primary, #fff);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.errorState {
+  text-align: center;
+  padding: 32px 16px;
+  color: var(--color-error, #f44336);
+  font-size: 15px;
+}

--- a/src/components/ui/DriveFileBrowser.test.tsx
+++ b/src/components/ui/DriveFileBrowser.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+// ---------- mocks ----------
+
+vi.mock('react-icons/io5', () => ({
+  IoClose: (props: any) => <span data-testid="icon-close" {...props} />,
+  IoDocumentTextOutline: (props: any) => <span data-testid="icon-doc" {...props} />,
+  IoChevronForward: (props: any) => <span data-testid="icon-chevron" {...props} />,
+}));
+
+const mockListRecentMarkdownFiles = vi.fn();
+const mockSearchMarkdownFiles = vi.fn();
+
+vi.mock('../../services/googleDrive', () => ({
+  listRecentMarkdownFiles: (...args: unknown[]) => mockListRecentMarkdownFiles(...args),
+  searchMarkdownFiles: (...args: unknown[]) => mockSearchMarkdownFiles(...args),
+}));
+
+vi.mock('../../hooks', () => ({
+  useLanguage: () => ({
+    t: {
+      driveBrowser: {
+        title: 'Select a File',
+        searchPlaceholder: 'Search...',
+        recentFiles: 'Recent Files',
+        noResults: 'No files found',
+        loading: 'Loading...',
+        error: 'Failed to load files',
+        safariHint: 'Open in Safari first.',
+      },
+    },
+    language: 'en',
+    setLanguage: vi.fn(),
+  }),
+}));
+
+// ---------- helpers ----------
+
+import { DriveFileBrowser } from './DriveFileBrowser';
+
+function renderBrowser(overrides = {}) {
+  const defaultProps = {
+    accessToken: 'test-token',
+    onSelect: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+  const result = render(<DriveFileBrowser {...defaultProps} />);
+  return { ...result, ...defaultProps };
+}
+
+// ---------- tests ----------
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  mockListRecentMarkdownFiles.mockResolvedValue([
+    { id: '1', name: 'readme.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
+    { id: '2', name: 'notes.md', mimeType: 'text/markdown', modifiedTime: '2025-01-02' },
+  ]);
+  mockSearchMarkdownFiles.mockResolvedValue([
+    { id: '3', name: 'search-result.md', mimeType: 'text/markdown', modifiedTime: '2025-01-03' },
+  ]);
+});
+
+describe('DriveFileBrowser', () => {
+  it('renders title and close button', async () => {
+    renderBrowser();
+    expect(screen.getByText('Select a File')).toBeTruthy();
+    expect(screen.getByLabelText('Close')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('readme.md')).toBeTruthy();
+    });
+  });
+
+  it('renders search input', async () => {
+    renderBrowser();
+    expect(screen.getByPlaceholderText('Search...')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('readme.md')).toBeTruthy();
+    });
+  });
+
+  it('shows loading state initially', () => {
+    // Delay the resolution to see loading state
+    mockListRecentMarkdownFiles.mockReturnValue(new Promise(() => {}));
+    renderBrowser();
+    expect(screen.getByText('Loading...')).toBeTruthy();
+  });
+
+  it('shows recent files after loading', async () => {
+    renderBrowser();
+
+    await waitFor(() => {
+      expect(screen.getByText('readme.md')).toBeTruthy();
+      expect(screen.getByText('notes.md')).toBeTruthy();
+    });
+    expect(screen.getByText('Recent Files')).toBeTruthy();
+  });
+
+  it('calls onSelect when clicking a file', async () => {
+    const { onSelect } = renderBrowser();
+
+    await waitFor(() => {
+      expect(screen.getByText('readme.md')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('readme.md'));
+    expect(onSelect).toHaveBeenCalledWith({ id: '1', name: 'readme.md' });
+  });
+
+  it('calls onSelect on Enter key press', async () => {
+    const { onSelect } = renderBrowser();
+
+    await waitFor(() => {
+      expect(screen.getByText('readme.md')).toBeTruthy();
+    });
+
+    const fileItem = screen.getByText('readme.md').closest('[role="button"]')!;
+    fireEvent.keyDown(fileItem, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith({ id: '1', name: 'readme.md' });
+  });
+
+  it('calls onCancel when clicking close button', async () => {
+    const { onCancel } = renderBrowser();
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when pressing Escape', async () => {
+    const { onCancel } = renderBrowser();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when clicking overlay background', async () => {
+    const { onCancel, container } = renderBrowser();
+    const overlay = container.querySelector('[class*="overlay"]')!;
+    fireEvent.click(overlay);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onCancel when clicking inside the panel', async () => {
+    const { onCancel } = renderBrowser();
+
+    await waitFor(() => {
+      expect(screen.getByText('Select a File')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Select a File'));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('shows empty state when no files found', async () => {
+    mockListRecentMarkdownFiles.mockResolvedValue([]);
+    renderBrowser();
+
+    await waitFor(() => {
+      expect(screen.getByText('No files found')).toBeTruthy();
+      expect(screen.getByText('Open in Safari first.')).toBeTruthy();
+    });
+  });
+
+  it('shows error state when API fails', async () => {
+    mockListRecentMarkdownFiles.mockRejectedValue(new Error('API error'));
+    renderBrowser();
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load files')).toBeTruthy();
+    });
+  });
+
+  it('searches files with debounce', async () => {
+    vi.useFakeTimers();
+    renderBrowser();
+
+    // Wait for initial load
+    await vi.advanceTimersByTimeAsync(10);
+
+    const input = screen.getByPlaceholderText('Search...');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    // Before debounce
+    expect(mockSearchMarkdownFiles).not.toHaveBeenCalled();
+
+    // After debounce (300ms)
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(mockSearchMarkdownFiles).toHaveBeenCalledWith('test-token', 'test');
+
+    vi.useRealTimers();
+  });
+
+  it('reloads recent files when search query is cleared', async () => {
+    vi.useFakeTimers();
+    renderBrowser();
+
+    // Wait for initial load
+    await vi.advanceTimersByTimeAsync(10);
+    mockListRecentMarkdownFiles.mockClear();
+
+    const input = screen.getByPlaceholderText('Search...');
+
+    // Type then clear
+    fireEvent.change(input, { target: { value: 'test' } });
+    await vi.advanceTimersByTimeAsync(300);
+
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(mockListRecentMarkdownFiles).toHaveBeenCalledWith('test-token');
+
+    vi.useRealTimers();
+  });
+});

--- a/src/components/ui/DriveFileBrowser.tsx
+++ b/src/components/ui/DriveFileBrowser.tsx
@@ -1,0 +1,212 @@
+/**
+ * DriveFileBrowser - iOS PWA モードでの Google Picker 代替
+ * Drive REST API を使用したアプリ内ファイルブラウザ
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  IoClose,
+  IoDocumentTextOutline,
+  IoChevronForward,
+} from 'react-icons/io5';
+import {
+  searchMarkdownFiles,
+  listRecentMarkdownFiles,
+} from '../../services/googleDrive';
+import { useLanguage } from '../../hooks';
+import type { DriveFile } from '../../types/googleDrive';
+import styles from './DriveFileBrowser.module.css';
+
+export interface DriveFileBrowserProps {
+  accessToken: string;
+  onSelect: (result: { id: string; name: string }) => void;
+  onCancel: () => void;
+}
+
+export function DriveFileBrowser({
+  accessToken,
+  onSelect,
+  onCancel,
+}: DriveFileBrowserProps) {
+  const { t } = useLanguage();
+  const [query, setQuery] = useState('');
+  const [files, setFiles] = useState<DriveFile[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 初期表示: 最近のファイルを取得
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    listRecentMarkdownFiles(accessToken)
+      .then((result) => {
+        if (!cancelled) setFiles(result);
+      })
+      .catch(() => {
+        if (!cancelled) setError(t.driveBrowser.error);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accessToken, t.driveBrowser.error]);
+
+  // 検索: debounce 300ms
+  const handleSearch = useCallback(
+    (value: string) => {
+      setQuery(value);
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+
+      if (!value.trim()) {
+        // 空文字の場合は最近のファイルに戻す
+        setIsLoading(true);
+        setError(null);
+        listRecentMarkdownFiles(accessToken)
+          .then(setFiles)
+          .catch(() => setError(t.driveBrowser.error))
+          .finally(() => setIsLoading(false));
+        return;
+      }
+
+      debounceRef.current = setTimeout(() => {
+        setIsLoading(true);
+        setError(null);
+        searchMarkdownFiles(accessToken, value)
+          .then(setFiles)
+          .catch(() => setError(t.driveBrowser.error))
+          .finally(() => setIsLoading(false));
+      }, 300);
+    },
+    [accessToken, t.driveBrowser.error],
+  );
+
+  // debounce タイマーのクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  // 入力にフォーカス
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Escape キーで閉じる
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  // オーバーレイ背景クリックで閉じる
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onCancel();
+      }
+    },
+    [onCancel],
+  );
+
+  return (
+    <div className={styles.overlay} onClick={handleOverlayClick}>
+      <div className={styles.panel}>
+        {/* ヘッダー */}
+        <div className={styles.header}>
+          <h2 className={styles.title}>{t.driveBrowser.title}</h2>
+          <button
+            className={styles.closeButton}
+            onClick={onCancel}
+            type="button"
+            aria-label="Close"
+          >
+            <IoClose size={22} />
+          </button>
+        </div>
+
+        {/* 検索 */}
+        <div className={styles.searchWrapper}>
+          <input
+            ref={inputRef}
+            className={styles.searchInput}
+            type="text"
+            placeholder={t.driveBrowser.searchPlaceholder}
+            value={query}
+            onChange={(e) => handleSearch(e.target.value)}
+          />
+        </div>
+
+        {/* ファイルリスト */}
+        <div className={styles.fileList}>
+          {!query.trim() && !isLoading && !error && files.length > 0 && (
+            <div className={styles.sectionLabel}>
+              {t.driveBrowser.recentFiles}
+            </div>
+          )}
+
+          {isLoading && (
+            <div className={styles.loadingState}>
+              <div className={styles.spinner} />
+              <span>{t.driveBrowser.loading}</span>
+            </div>
+          )}
+
+          {error && (
+            <div className={styles.errorState}>{error}</div>
+          )}
+
+          {!isLoading && !error && files.length === 0 && (
+            <div className={styles.emptyState}>
+              <p className={styles.emptyMessage}>
+                {t.driveBrowser.noResults}
+              </p>
+              <p className={styles.emptyHint}>
+                {t.driveBrowser.safariHint}
+              </p>
+            </div>
+          )}
+
+          {!isLoading &&
+            !error &&
+            files.map((file) => (
+              <div
+                key={file.id}
+                className={styles.fileItem}
+                onClick={() => onSelect({ id: file.id, name: file.name })}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter')
+                    onSelect({ id: file.id, name: file.name });
+                }}
+              >
+                <div className={styles.fileIcon}>
+                  <IoDocumentTextOutline size={20} />
+                </div>
+                <span className={styles.fileName}>{file.name}</span>
+                <IoChevronForward size={16} className={styles.chevron} />
+              </div>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,3 +9,4 @@ export { FontSettingsPanel } from './FontSettingsPanel';
 export { Tooltip } from './Tooltip';
 export { GoogleLogo } from './GoogleLogo';
 export { OAuthOverlay } from './OAuthOverlay';
+export { DriveFileBrowser } from './DriveFileBrowser';

--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -1339,6 +1339,104 @@ describe('useGoogleAuth', () => {
       // gapi.client を復元
       window.gapi.client = originalClient;
     });
+
+    it('should show DriveFileBrowser in iOS PWA mode instead of Picker', async () => {
+      authenticateHook();
+
+      // Simulate iOS + standalone (PWA) environment
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)',
+        writable: true,
+        configurable: true,
+      });
+      window.matchMedia = vi.fn((query: string) => ({
+        matches: query === '(display-mode: standalone)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      // driveFileBrowserProps should initially be null
+      expect(result.current.driveFileBrowserProps).toBeNull();
+
+      // Open drive picker should set driveFileBrowserProps instead of building Picker
+      let pickerPromise: Promise<any>;
+      act(() => {
+        pickerPromise = result.current.openDrivePicker();
+      });
+
+      // driveFileBrowserProps should now be set
+      expect(result.current.driveFileBrowserProps).not.toBeNull();
+      expect(result.current.driveFileBrowserProps!.accessToken).toBe('valid-token');
+
+      // Simulate user selecting a file
+      await act(async () => {
+        result.current.driveFileBrowserProps!.onSelect({ id: 'file-1', name: 'test.md' });
+      });
+
+      const pickerResult = await pickerPromise!;
+      expect(pickerResult).toEqual({ id: 'file-1', name: 'test.md' });
+      expect(result.current.driveFileBrowserProps).toBeNull();
+
+      // Restore
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64)',
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('should resolve null when DriveFileBrowser is cancelled in iOS PWA mode', async () => {
+      authenticateHook();
+
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)',
+        writable: true,
+        configurable: true,
+      });
+      window.matchMedia = vi.fn((query: string) => ({
+        matches: query === '(display-mode: standalone)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      let pickerPromise: Promise<any>;
+      act(() => {
+        pickerPromise = result.current.openDrivePicker();
+      });
+
+      expect(result.current.driveFileBrowserProps).not.toBeNull();
+
+      // Simulate cancel
+      await act(async () => {
+        result.current.driveFileBrowserProps!.onCancel();
+      });
+
+      const pickerResult = await pickerPromise!;
+      expect(pickerResult).toBeNull();
+      expect(result.current.driveFileBrowserProps).toBeNull();
+
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64)',
+        writable: true,
+        configurable: true,
+      });
+    });
   });
 
 });

--- a/src/hooks/useGoogleAuth.ts
+++ b/src/hooks/useGoogleAuth.ts
@@ -14,6 +14,8 @@ import {
 } from '../services/googleDrive';
 import { storage } from '../services/storage';
 import { trackEvent } from '../utils/analytics';
+import { isIOS, isStandaloneMode, isIosPwa } from '../utils/platform';
+import type { DriveFileBrowserProps } from '../components/ui/DriveFileBrowser';
 
 // 環境変数から設定を取得
 const API_KEY = import.meta.env.VITE_GOOGLE_API_KEY || '';
@@ -116,6 +118,7 @@ export interface UseGoogleAuthReturn {
   fetchFileContent: (fileId: string, signal?: AbortSignal) => Promise<string | null>;
   clearResults: () => void;
   openDrivePicker: (options?: OpenDrivePickerOptions) => Promise<PickerResult | null>;
+  driveFileBrowserProps: DriveFileBrowserProps | null;
 }
 
 // スクリプトを動的に読み込む
@@ -197,6 +200,7 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
   const [recentFiles, setRecentFiles] = useState<DriveFile[]>([]);
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [driveFileBrowserState, setDriveFileBrowserState] = useState<DriveFileBrowserProps | null>(null);
 
   const tokenClientRef = useRef<TokenClient | null>(null);
   const pickerInited = useRef(false);
@@ -301,10 +305,8 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
 
     if (tokenClientRef.current) {
       // iOS Safari / PWA モードでのポップアップブロック検出
-      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-        (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
-      const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
-        ('standalone' in navigator && (navigator as unknown as { standalone: boolean }).standalone);
+      const iosDevice = isIOS();
+      const isStandalone = isStandaloneMode();
 
       setIsAuthenticating(true);
       setError(null);
@@ -316,7 +318,7 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
       // タイムアウト設定（60秒で自動キャンセル）
       authTimeoutRef.current = setTimeout(() => {
         clearAuthState();
-        if (isIOS) {
+        if (iosDevice) {
           setError('auth_timeout_ios');
         } else {
           setError('auth_timeout');
@@ -357,9 +359,9 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
       errorCallbackRef.current = (err: PopupError) => {
         clearAuthState();
         if (err.type === 'popup_failed_to_open') {
-          if (isIOS && isStandalone) {
+          if (iosDevice && isStandalone) {
             setError('auth_popup_blocked_pwa');
-          } else if (isIOS) {
+          } else if (iosDevice) {
             setError('auth_popup_blocked_ios');
           } else {
             setError('auth_popup_blocked');
@@ -367,7 +369,7 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
         } else if (err.type === 'popup_closed') {
           // iOS PWA モードでは、Google の Cookie エラーでユーザーがポップアップを
           // 閉じた可能性が高いため、対処方法を案内する
-          if (isIOS && isStandalone) {
+          if (iosDevice && isStandalone) {
             setError('auth_popup_blocked_pwa');
           } else {
             setError(null);
@@ -381,9 +383,9 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
         tokenClientRef.current.requestAccessToken({ prompt: '', state });
       } catch {
         clearAuthState();
-        if (isIOS && isStandalone) {
+        if (iosDevice && isStandalone) {
           setError('auth_popup_blocked_pwa');
-        } else if (isIOS) {
+        } else if (iosDevice) {
           setError('auth_popup_blocked_ios');
         } else {
           setError('auth_popup_blocked');
@@ -506,6 +508,22 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
         return;
       }
 
+      // iOS PWA モードでは Google Picker が動作しないため、アプリ内ファイルブラウザを表示
+      if (isIosPwa()) {
+        setDriveFileBrowserState({
+          accessToken,
+          onSelect: (result) => {
+            setDriveFileBrowserState(null);
+            resolve(result);
+          },
+          onCancel: () => {
+            setDriveFileBrowserState(null);
+            resolve(null);
+          },
+        });
+        return;
+      }
+
       if (!pickerInited.current) {
         setError('Picker API が読み込まれていません');
         resolve(null);
@@ -576,5 +594,6 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     fetchFileContent,
     clearResults,
     openDrivePicker,
+    driveFileBrowserProps: driveFileBrowserState,
   };
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -327,6 +327,17 @@ export const en = {
     openInSafari: 'Open in Safari',
   },
 
+  // Drive File Browser (iOS PWA)
+  driveBrowser: {
+    title: 'Select a File',
+    searchPlaceholder: 'Search Markdown files...',
+    recentFiles: 'Recent Files',
+    noResults: 'No files found',
+    loading: 'Loading...',
+    error: 'Failed to load files',
+    safariHint: 'To access new files, open them in Safari first.',
+  },
+
   // Add to Home Screen
   addToHomeScreen: {
     title: 'Add to Home Screen',
@@ -673,6 +684,15 @@ export type Translations = {
     popupBlockedPwa: string;
     thirdPartyCookieHint: string;
     openInSafari: string;
+  };
+  driveBrowser: {
+    title: string;
+    searchPlaceholder: string;
+    recentFiles: string;
+    noResults: string;
+    loading: string;
+    error: string;
+    safariHint: string;
   };
   addToHomeScreen: {
     title: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -329,6 +329,17 @@ export const ja: Translations = {
     openInSafari: 'Safariで開く',
   },
 
+  // Drive File Browser (iOS PWA)
+  driveBrowser: {
+    title: 'ファイルを選択',
+    searchPlaceholder: 'Markdownファイルを検索...',
+    recentFiles: '最近のファイル',
+    noResults: 'ファイルが見つかりません',
+    loading: '読み込み中...',
+    error: 'ファイルの読み込みに失敗しました',
+    safariHint: '新しいファイルにアクセスするには、まずSafariで開いてください。',
+  },
+
   // Add to Home Screen
   addToHomeScreen: {
     title: 'ホーム画面に追加',

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -59,6 +59,7 @@ vi.mock('../components/ui', () => ({
   UserMenu: ({ isAuthenticated }: any) => <div data-testid="user-menu" data-authenticated={isAuthenticated} />,
   GoogleLogo: ({ size }: any) => <span data-testid="google-logo" />,
   OAuthOverlay: () => null,
+  DriveFileBrowser: () => <div data-testid="drive-file-browser" />,
 }));
 
 vi.mock('../components/ui/AddToHomeScreenBanner', () => ({
@@ -79,6 +80,7 @@ const mockAuthState = {
   authenticate: mockAuthenticate,
   logout: mockLogout,
   openDrivePicker: mockOpenDrivePicker,
+  driveFileBrowserProps: null as any,
 };
 
 const mockPickerState = {
@@ -245,6 +247,7 @@ beforeEach(() => {
     authenticate: mockAuthenticate,
     logout: mockLogout,
     openDrivePicker: mockOpenDrivePicker,
+    driveFileBrowserProps: null,
   });
 
   // Reset picker settings

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -23,7 +23,7 @@ import {
   IoSettingsOutline,
   IoPlayOutline,
 } from 'react-icons/io5';
-import { Button, LoadingSpinner, FAB, SettingsMenu, UserMenu, GoogleLogo, OAuthOverlay } from '../components/ui';
+import { Button, LoadingSpinner, FAB, SettingsMenu, UserMenu, GoogleLogo, OAuthOverlay, DriveFileBrowser } from '../components/ui';
 import { AddToHomeScreenBanner } from '../components/ui/AddToHomeScreenBanner';
 import { useGoogleAuth, useTheme, useLanguage, usePickerSettings } from '../hooks';
 import { useFilePicker } from '../hooks';
@@ -60,6 +60,7 @@ export default function HomePage() {
     cancelAuth,
     logout,
     openDrivePicker,
+    driveFileBrowserProps,
   } = useGoogleAuth();
 
   const { openPicker } = useFilePicker();
@@ -688,6 +689,9 @@ export default function HomePage() {
         onRetry={authenticate}
         onDismissError={cancelAuth}
       />
+
+      {/* iOS PWA 用 Drive ファイルブラウザ */}
+      {driveFileBrowserProps && <DriveFileBrowser {...driveFileBrowserProps} />}
     </div>
   );
 }

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock('react-icons/io5', () => ({
 vi.mock('../components/ui', () => ({
   GoogleLogo: ({ size }: any) => <span data-testid="google-logo" />,
   OAuthOverlay: () => null,
+  DriveFileBrowser: () => <div data-testid="drive-file-browser" />,
 }));
 
 const mockAuthenticate = vi.fn();
@@ -30,6 +31,7 @@ const mockAuthState = {
   isAuthenticated: false,
   authenticate: mockAuthenticate,
   openDrivePicker: mockOpenDrivePicker,
+  driveFileBrowserProps: null as any,
 };
 
 vi.mock('../hooks', () => ({
@@ -65,6 +67,7 @@ beforeEach(() => {
     isAuthenticated: false,
     authenticate: mockAuthenticate,
     openDrivePicker: mockOpenDrivePicker,
+    driveFileBrowserProps: null,
   });
 
   window.matchMedia = vi.fn(() => ({

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -8,7 +8,7 @@ import {
   IoClose,
   IoFolderOpenOutline,
 } from 'react-icons/io5';
-import { GoogleLogo, OAuthOverlay } from '../components/ui';
+import { GoogleLogo, OAuthOverlay, DriveFileBrowser } from '../components/ui';
 import { useGoogleAuth, useLanguage } from '../hooks';
 import { trackEvent } from '../utils/analytics';
 import styles from './SearchPage.module.css';
@@ -22,6 +22,7 @@ export default function SearchPage() {
     authenticate,
     cancelAuth,
     openDrivePicker,
+    driveFileBrowserProps,
   } = useGoogleAuth();
 
   const navigate = useNavigate();
@@ -100,6 +101,9 @@ export default function SearchPage() {
         onRetry={authenticate}
         onDismissError={cancelAuth}
       />
+
+      {/* iOS PWA 用 Drive ファイルブラウザ */}
+      {driveFileBrowserProps && <DriveFileBrowser {...driveFileBrowserProps} />}
     </div>
   );
 }

--- a/src/utils/platform.test.ts
+++ b/src/utils/platform.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isIOS, isStandaloneMode, isIosPwa } from './platform';
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: ua,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function setStandaloneMediaQuery(matches: boolean) {
+  window.matchMedia = vi.fn((query: string) => ({
+    matches: query === '(display-mode: standalone)' ? matches : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+afterEach(() => {
+  setUserAgent('Mozilla/5.0 (X11; Linux x86_64)');
+  setStandaloneMediaQuery(false);
+  // Remove navigator.standalone if set
+  if ('standalone' in navigator) {
+    Object.defineProperty(navigator, 'standalone', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  }
+});
+
+describe('isIOS', () => {
+  it('returns true for iPhone user agent', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)');
+    expect(isIOS()).toBe(true);
+  });
+
+  it('returns true for iPad user agent', () => {
+    setUserAgent('Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X)');
+    expect(isIOS()).toBe(true);
+  });
+
+  it('returns true for Mac with touch (iPad desktop mode)', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)');
+    Object.defineProperty(document, 'ontouchend', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    expect(isIOS()).toBe(true);
+    delete (document as any).ontouchend;
+  });
+
+  it('returns false for desktop Chrome', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36');
+    expect(isIOS()).toBe(false);
+  });
+
+  it('returns false for Android', () => {
+    setUserAgent('Mozilla/5.0 (Linux; Android 13)');
+    expect(isIOS()).toBe(false);
+  });
+});
+
+describe('isStandaloneMode', () => {
+  it('returns true when display-mode: standalone matches', () => {
+    setStandaloneMediaQuery(true);
+    expect(isStandaloneMode()).toBe(true);
+  });
+
+  it('returns true when navigator.standalone is true', () => {
+    setStandaloneMediaQuery(false);
+    Object.defineProperty(navigator, 'standalone', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    expect(isStandaloneMode()).toBe(true);
+  });
+
+  it('returns false in normal browser mode', () => {
+    setStandaloneMediaQuery(false);
+    expect(isStandaloneMode()).toBe(false);
+  });
+});
+
+describe('isIosPwa', () => {
+  it('returns true for iOS + standalone', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)');
+    setStandaloneMediaQuery(true);
+    expect(isIosPwa()).toBe(true);
+  });
+
+  it('returns false for iOS + non-standalone', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)');
+    setStandaloneMediaQuery(false);
+    expect(isIosPwa()).toBe(false);
+  });
+
+  it('returns false for non-iOS + standalone', () => {
+    setUserAgent('Mozilla/5.0 (Linux; Android 13)');
+    setStandaloneMediaQuery(true);
+    expect(isIosPwa()).toBe(false);
+  });
+
+  it('returns false for desktop browser', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)');
+    setStandaloneMediaQuery(false);
+    expect(isIosPwa()).toBe(false);
+  });
+});

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,25 @@
+/**
+ * プラットフォーム検出ユーティリティ
+ */
+
+/** iOS デバイスかどうかを判定 */
+export function isIOS(): boolean {
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+  );
+}
+
+/** スタンドアロン（PWA）モードかどうかを判定 */
+export function isStandaloneMode(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    ('standalone' in navigator &&
+      !!(navigator as unknown as { standalone: boolean }).standalone)
+  );
+}
+
+/** iOS PWA モードかどうかを判定 */
+export function isIosPwa(): boolean {
+  return isIOS() && isStandaloneMode();
+}


### PR DESCRIPTION
## Summary

- iOS PWA（ホーム画面に追加）モードで Google Picker が動作しない問題の代替として、Drive REST API ベースのアプリ内ファイルブラウザを追加
- `isIosPwa()` 判定で iOS PWA モードのみ DriveFileBrowser を表示し、それ以外は従来通り Google Picker を使用
- 既存の `searchMarkdownFiles` / `listRecentMarkdownFiles` を再利用し、`openDrivePicker` の戻り値は変更なし

## 変更内容

| ファイル | 操作 | 内容 |
|---------|------|------|
| `src/utils/platform.ts` | 新規 | `isIOS()`, `isStandaloneMode()`, `isIosPwa()` ユーティリティ |
| `src/components/ui/DriveFileBrowser.tsx` | 新規 | 検索 + ファイル一覧オーバーレイ UI |
| `src/components/ui/DriveFileBrowser.module.css` | 新規 | スタイル |
| `src/hooks/useGoogleAuth.ts` | 変更 | iOS PWA 分岐追加 + プラットフォーム検出の共通化 |
| `src/i18n/locales/en.ts`, `ja.ts` | 変更 | `driveBrowser` セクション追加 |
| `src/pages/HomePage.tsx`, `SearchPage.tsx` | 変更 | DriveFileBrowser レンダリング追加 |

## Test plan

- [x] `bunx tsc --noEmit` 型チェック通過
- [x] `bunx vitest run` 関連 113 テスト全通過（新規 28 テスト追加）
- [x] `bun run build` ビルド成功
- [ ] iOS Safari → ホーム画面に追加 → PWA モードで起動 → ファイル選択ボタン → DriveFileBrowser 表示確認
- [ ] デスクトップブラウザで従来通り Google Picker が表示されることを確認

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)