### PR TITLE
fix: トークン失効時の袋小路を解消するサイレント再取得フロー

### DIFF
--- a/src/components/ui/OAuthOverlay.test.tsx
+++ b/src/components/ui/OAuthOverlay.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../hooks', () => ({
         popupBlockedPwa: 'Google Sign-in may not work from Home Screen.',
         thirdPartyCookieHint: 'Disable "Prevent Cross-Site Tracking".',
         openInSafari: 'Open in Safari',
+        sessionExpired: 'Your Google session has expired.',
       },
       viewer: {
         retry: 'Retry',
@@ -124,6 +125,23 @@ describe('OAuthOverlay', () => {
     render(<OAuthOverlay {...defaultProps} error="auth_timeout" />);
     fireEvent.click(screen.getByText('Cancel'));
     expect(defaultProps.onDismissError).toHaveBeenCalledOnce();
+  });
+
+  // --- Session expired ---
+
+  it('should show session expired message with retry button', () => {
+    render(<OAuthOverlay {...defaultProps} error="auth_session_expired" />);
+    expect(screen.getByText('Your Google session has expired.')).toBeTruthy();
+    expect(screen.getByText('Retry')).toBeTruthy();
+    expect(screen.getByText('Cancel')).toBeTruthy();
+    // Session expired should not show the third-party cookie hint
+    expect(screen.queryByText('Disable "Prevent Cross-Site Tracking".')).toBeNull();
+  });
+
+  it('should invoke onRetry from session expired dialog', () => {
+    render(<OAuthOverlay {...defaultProps} error="auth_session_expired" />);
+    fireEvent.click(screen.getByText('Retry'));
+    expect(defaultProps.onRetry).toHaveBeenCalledOnce();
   });
 
   // --- Priority: error takes precedence over authenticating ---

--- a/src/components/ui/OAuthOverlay.tsx
+++ b/src/components/ui/OAuthOverlay.tsx
@@ -13,6 +13,7 @@ const ERROR_KEY_MAP: Record<string, keyof typeof import('../../i18n/locales/en')
   auth_popup_blocked: 'popupBlocked',
   auth_popup_blocked_ios: 'popupBlockedIos',
   auth_popup_blocked_pwa: 'popupBlockedPwa',
+  auth_session_expired: 'sessionExpired',
 };
 
 // iOS Safari でサードパーティ Cookie のヒントを表示すべきエラー

--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -12,18 +12,32 @@ vi.mock('../utils/analytics', () => ({
   trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
 }));
 
-vi.mock('../services/googleDrive', () => ({
-  fetchUserInfo: vi.fn(async () => ({ email: 'test@example.com', name: 'Test User', picture: '' })),
-  searchMarkdownFiles: vi.fn(async () => [
-    { id: '1', name: 'result.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
-  ]),
-  listRecentMarkdownFiles: vi.fn(async () => [
-    { id: '2', name: 'recent.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
-  ]),
-  fetchFileContent: vi.fn(async () => '# File content'),
-}));
+vi.mock('../services/googleDrive', () => {
+  class MockUnauthorizedError extends Error {
+    readonly status: number;
+    constructor(status = 401) {
+      super('unauthorized');
+      this.name = 'UnauthorizedError';
+      this.status = status;
+    }
+  }
+  return {
+    fetchUserInfo: vi.fn(async () => ({ email: 'test@example.com', name: 'Test User', picture: '' })),
+    searchMarkdownFiles: vi.fn(async () => [
+      { id: '1', name: 'result.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
+    ]),
+    listRecentMarkdownFiles: vi.fn(async () => [
+      { id: '2', name: 'recent.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
+    ]),
+    fetchFileContent: vi.fn(async () => '# File content'),
+    UnauthorizedError: MockUnauthorizedError,
+  };
+});
 
 const googleDrive = await import('../services/googleDrive');
+const MockUnauthorizedError = googleDrive.UnauthorizedError as unknown as new (
+  status?: number
+) => Error;
 
 // --- localStorage mock ---
 
@@ -982,6 +996,253 @@ describe('useGoogleAuth', () => {
           await result.current.fetchFileContent('file-123');
         })
       ).rejects.toThrow('Aborted');
+    });
+  });
+
+  // --- silent refresh / withReauth ---
+
+  describe('silent refresh on 401', () => {
+    function setupAuthenticated(opts?: {
+      captureClient?: (client: any) => void;
+      captureErrorCallback?: (cb: (err: { type: string }) => void) => void;
+    }) {
+      const futureExpiry = String(Date.now() + 60 * 60 * 1000);
+      storageMock.getItem.mockImplementation((key: string) => {
+        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveAccessToken') return 'stale-token';
+        if (key === 'googleDriveTokenExpiry') return futureExpiry;
+        return null;
+      });
+
+      const mockRequestAccessToken = vi.fn();
+      const tokenClient: any = {
+        requestAccessToken: mockRequestAccessToken,
+        callback: vi.fn(),
+      };
+      window.google.accounts.oauth2.initTokenClient = vi.fn((config: any) => {
+        opts?.captureErrorCallback?.(config.error_callback);
+        return tokenClient;
+      }) as any;
+      opts?.captureClient?.(tokenClient);
+      return { tokenClient, mockRequestAccessToken };
+    }
+
+    it('retries the call transparently after silent refresh succeeds', async () => {
+      let capturedClient: any;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      // 1 回目は 401、2 回目は成功
+      vi.mocked(googleDrive.searchMarkdownFiles)
+        .mockRejectedValueOnce(new MockUnauthorizedError(401))
+        .mockResolvedValueOnce([
+          { id: 'x', name: 'after-refresh.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
+        ]);
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      // サイレント再取得が呼ばれたらトークン client.callback を発火
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => {
+            capturedClient.callback({
+              access_token: 'fresh-token',
+              expires_in: 3600,
+            });
+          }, 0);
+        }
+      });
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      expect(mockRequestAccessToken).toHaveBeenCalledWith({ prompt: 'none' });
+      expect(vi.mocked(googleDrive.searchMarkdownFiles)).toHaveBeenCalledTimes(2);
+      expect(result.current.results[0].name).toBe('after-refresh.md');
+      expect(result.current.accessToken).toBe('fresh-token');
+      expect(result.current.error).toBeNull();
+    });
+
+    it('sets auth_session_expired when silent refresh error_callback fires', async () => {
+      let capturedErrorCallback: ((err: { type: string }) => void) | undefined;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureErrorCallback: (cb) => {
+          capturedErrorCallback = cb;
+        },
+      });
+
+      vi.mocked(googleDrive.searchMarkdownFiles).mockRejectedValue(
+        new MockUnauthorizedError(401)
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => capturedErrorCallback?.({ type: 'user_logged_out' }), 0);
+        }
+      });
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      expect(result.current.error).toBe('auth_session_expired');
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.accessToken).toBeNull();
+      expect(storageMock.removeItem).toHaveBeenCalledWith('googleDriveAccessToken');
+    });
+
+    it('sets auth_session_expired when silent refresh requestAccessToken throws', async () => {
+      let capturedClient: any;
+      setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      vi.mocked(googleDrive.searchMarkdownFiles).mockRejectedValue(
+        new MockUnauthorizedError(401)
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      capturedClient.requestAccessToken = vi.fn((opts: any) => {
+        if (opts?.prompt === 'none') {
+          throw new Error('silent failed');
+        }
+      });
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      expect(result.current.error).toBe('auth_session_expired');
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    it('does not retry on non-auth errors', async () => {
+      const { mockRequestAccessToken } = setupAuthenticated();
+
+      vi.mocked(googleDrive.searchMarkdownFiles).mockRejectedValueOnce(
+        new Error('Network timeout')
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      // prompt: 'none' は呼ばれていないこと
+      expect(
+        mockRequestAccessToken.mock.calls.filter(
+          (c) => c[0]?.prompt === 'none'
+        )
+      ).toHaveLength(0);
+      expect(result.current.error).toBe('Network timeout');
+    });
+
+    it('recovers loadRecentFiles via silent refresh', async () => {
+      let capturedClient: any;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      vi.mocked(googleDrive.listRecentMarkdownFiles)
+        .mockRejectedValueOnce(new MockUnauthorizedError(401))
+        .mockResolvedValueOnce([
+          { id: 'r', name: 'refreshed.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
+        ]);
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => {
+            capturedClient.callback({ access_token: 'fresh2', expires_in: 3600 });
+          }, 0);
+        }
+      });
+
+      await act(async () => {
+        await result.current.loadRecentFiles();
+      });
+
+      expect(result.current.recentFiles[0].name).toBe('refreshed.md');
+      expect(result.current.error).toBeNull();
+    });
+
+    it('recovers fetchFileContent via silent refresh', async () => {
+      let capturedClient: any;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      vi.mocked(googleDrive.fetchFileContent)
+        .mockRejectedValueOnce(new MockUnauthorizedError(401))
+        .mockResolvedValueOnce('# refreshed content');
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => {
+            capturedClient.callback({ access_token: 'fresh3', expires_in: 3600 });
+          }, 0);
+        }
+      });
+
+      let content: string | null = null;
+      await act(async () => {
+        content = await result.current.fetchFileContent('file-xyz');
+      });
+
+      expect(content).toBe('# refreshed content');
+    });
+
+    it('fetchFileContent returns null on session expired without leaking error', async () => {
+      let capturedErrorCallback: ((err: { type: string }) => void) | undefined;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureErrorCallback: (cb) => {
+          capturedErrorCallback = cb;
+        },
+      });
+
+      vi.mocked(googleDrive.fetchFileContent).mockRejectedValue(
+        new MockUnauthorizedError(401)
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => capturedErrorCallback?.({ type: 'invalid_request' }), 0);
+        }
+      });
+
+      let content: string | null | undefined;
+      await act(async () => {
+        content = await result.current.fetchFileContent('file-xyz');
+      });
+
+      expect(content).toBeNull();
+      expect(result.current.error).toBe('auth_session_expired');
     });
   });
 

--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -1151,6 +1151,69 @@ describe('useGoogleAuth', () => {
       expect(result.current.error).toBe('Network timeout');
     });
 
+    it('loadRecentFiles sets error and bails on session expired', async () => {
+      let capturedErrorCallback: ((err: { type: string }) => void) | undefined;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureErrorCallback: (cb) => {
+          capturedErrorCallback = cb;
+        },
+      });
+
+      vi.mocked(googleDrive.listRecentMarkdownFiles).mockRejectedValue(
+        new MockUnauthorizedError(401)
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => capturedErrorCallback?.({ type: 'user_logged_out' }), 0);
+        }
+      });
+
+      await act(async () => {
+        await result.current.loadRecentFiles();
+      });
+
+      expect(result.current.error).toBe('auth_session_expired');
+      expect(result.current.recentFiles).toEqual([]);
+    });
+
+    it('loadRecentFiles surfaces non-auth error messages', async () => {
+      setupAuthenticated();
+      vi.mocked(googleDrive.listRecentMarkdownFiles).mockRejectedValueOnce(
+        new Error('Quota exceeded')
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      await act(async () => {
+        await result.current.loadRecentFiles();
+      });
+
+      expect(result.current.error).toBe('Quota exceeded');
+    });
+
+    it('fetchFileContent surfaces non-auth error messages', async () => {
+      setupAuthenticated();
+      vi.mocked(googleDrive.fetchFileContent).mockRejectedValueOnce(
+        new Error('Boom')
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      let content: string | null | undefined;
+      await act(async () => {
+        content = await result.current.fetchFileContent('file-xyz');
+      });
+
+      expect(content).toBeNull();
+      expect(result.current.error).toBe('Boom');
+    });
+
     it('recovers loadRecentFiles via silent refresh', async () => {
       let capturedClient: any;
       const { mockRequestAccessToken } = setupAuthenticated({
@@ -1213,6 +1276,191 @@ describe('useGoogleAuth', () => {
       });
 
       expect(content).toBe('# refreshed content');
+    });
+
+    it('dedups concurrent silent refreshes into a single token request', async () => {
+      let capturedClient: any;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      // search / loadRecentFiles それぞれで 401 → 成功を返す
+      vi.mocked(googleDrive.searchMarkdownFiles)
+        .mockRejectedValueOnce(new MockUnauthorizedError(401))
+        .mockResolvedValueOnce([
+          { id: 'a', name: 'a.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
+        ]);
+      vi.mocked(googleDrive.listRecentMarkdownFiles)
+        .mockRejectedValueOnce(new MockUnauthorizedError(401))
+        .mockResolvedValueOnce([
+          { id: 'b', name: 'b.md', mimeType: 'text/markdown', modifiedTime: '2025-01-01' },
+        ]);
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      // サイレント再取得のコールバックを少し遅らせて、並行実行中に 2 本目が入るようにする
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => {
+            capturedClient.callback({
+              access_token: 'dedup-token',
+              expires_in: 3600,
+            });
+          }, 20);
+        }
+      });
+
+      await act(async () => {
+        await Promise.all([
+          result.current.search('q'),
+          result.current.loadRecentFiles(),
+        ]);
+      });
+
+      // requestAccessToken({ prompt: 'none' }) は 1 回だけ呼ばれる
+      const silentCalls = mockRequestAccessToken.mock.calls.filter(
+        (c) => c[0]?.prompt === 'none'
+      );
+      expect(silentCalls).toHaveLength(1);
+      expect(result.current.results[0].name).toBe('a.md');
+      expect(result.current.recentFiles[0].name).toBe('b.md');
+    });
+
+    it('falls back to session expired when tokenClient is not initialized', async () => {
+      const futureExpiry = String(Date.now() + 60 * 60 * 1000);
+      storageMock.getItem.mockImplementation((key: string) => {
+        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveAccessToken') return 'stale-token';
+        if (key === 'googleDriveTokenExpiry') return futureExpiry;
+        return null;
+      });
+
+      // initTokenClient が null を返し、tokenClientRef.current が未設定になる状況を再現
+      window.google.accounts.oauth2.initTokenClient = vi.fn(
+        () => null as any
+      ) as any;
+
+      vi.mocked(googleDrive.searchMarkdownFiles).mockRejectedValue(
+        new MockUnauthorizedError(401)
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      expect(result.current.error).toBe('auth_session_expired');
+      expect(result.current.accessToken).toBeNull();
+    });
+
+    it('silent refresh callback treats response.error as failure', async () => {
+      let capturedClient: any;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      vi.mocked(googleDrive.searchMarkdownFiles).mockRejectedValue(
+        new MockUnauthorizedError(401)
+      );
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => {
+            // Google からエラー付きレスポンスが返るパターン
+            capturedClient.callback({
+              error: 'interaction_required',
+              access_token: '',
+            });
+          }, 0);
+        }
+      });
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      expect(result.current.error).toBe('auth_session_expired');
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    it('handles second 401 after successful silent refresh by signaling session expired', async () => {
+      let capturedClient: any;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      // 初回も再試行も 401 を返す
+      vi.mocked(googleDrive.searchMarkdownFiles)
+        .mockRejectedValueOnce(new MockUnauthorizedError(401))
+        .mockRejectedValueOnce(new MockUnauthorizedError(401));
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => {
+            capturedClient.callback({
+              access_token: 'fresh-but-still-bad',
+              expires_in: 3600,
+            });
+          }, 0);
+        }
+      });
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      expect(result.current.error).toBe('auth_session_expired');
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(vi.mocked(googleDrive.searchMarkdownFiles)).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-throws non-auth errors from retry after silent refresh succeeded', async () => {
+      let capturedClient: any;
+      const { mockRequestAccessToken } = setupAuthenticated({
+        captureClient: (c) => {
+          capturedClient = c;
+        },
+      });
+
+      vi.mocked(googleDrive.searchMarkdownFiles)
+        .mockRejectedValueOnce(new MockUnauthorizedError(401))
+        .mockRejectedValueOnce(new Error('Network down'));
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      mockRequestAccessToken.mockImplementation((opts: any) => {
+        if (opts?.prompt === 'none') {
+          setTimeout(() => {
+            capturedClient.callback({
+              access_token: 'fresh-token',
+              expires_in: 3600,
+            });
+          }, 0);
+        }
+      });
+
+      await act(async () => {
+        await result.current.search('query');
+      });
+
+      // 非認証エラーはそのまま setError に流れ、session_expired ではない
+      expect(result.current.error).toBe('Network down');
     });
 
     it('fetchFileContent returns null on session expired without leaking error', async () => {

--- a/src/hooks/useGoogleAuth.ts
+++ b/src/hooks/useGoogleAuth.ts
@@ -11,6 +11,7 @@ import {
   searchMarkdownFiles,
   listRecentMarkdownFiles,
   fetchFileContent as fetchDriveFileContent,
+  UnauthorizedError,
 } from '../services/googleDrive';
 import { storage } from '../services/storage';
 import { trackEvent } from '../utils/analytics';
@@ -36,6 +37,9 @@ const OAUTH_STATE_KEY = 'oauth_state';
 
 // OAuth ポップアップタイムアウト（秒）
 const OAUTH_POPUP_TIMEOUT_MS = 60_000;
+
+// サイレント再取得のタイムアウト（ハングを防ぐ安全網）
+const SILENT_REFRESH_TIMEOUT_MS = 10_000;
 
 // Google API の型定義
 declare global {
@@ -207,6 +211,7 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
   const gisInited = useRef(false);
   const authTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const errorCallbackRef = useRef<((err: PopupError) => void) | null>(null);
+  const silentRefreshPromiseRef = useRef<Promise<string | null> | null>(null);
 
   // 初期化時にトークンを復元
   useEffect(() => {
@@ -410,6 +415,104 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     clearStoredToken();
   }, [accessToken]);
 
+  // ブラウザに Google セッションが残っていれば UI を出さずに access_token を再発行する。
+  // ITP や 3rd-party cookie 規制で失敗することがあり、その場合は null を返す。
+  const silentRefresh = useCallback((): Promise<string | null> => {
+    if (silentRefreshPromiseRef.current) {
+      return silentRefreshPromiseRef.current;
+    }
+    const client = tokenClientRef.current;
+    if (!client) {
+      return Promise.resolve(null);
+    }
+
+    const prevErrorCallback = errorCallbackRef.current;
+    let settled = false;
+    let resolver: (token: string | null) => void = () => {};
+
+    const promise = new Promise<string | null>((resolve) => {
+      resolver = resolve;
+    });
+
+    const settle = (token: string | null) => {
+      if (settled) return;
+      settled = true;
+      errorCallbackRef.current = prevErrorCallback;
+      resolver(token);
+    };
+
+    client.callback = async (response: TokenResponse) => {
+      if (response.error || !response.access_token) {
+        settle(null);
+        return;
+      }
+      await saveToken(response.access_token, response.expires_in || 3600);
+      setAccessToken(response.access_token);
+      setIsAuthenticated(true);
+      setError(null);
+      settle(response.access_token);
+    };
+
+    errorCallbackRef.current = () => settle(null);
+
+    const timeoutId = setTimeout(() => settle(null), SILENT_REFRESH_TIMEOUT_MS);
+
+    try {
+      // prompt: 'none' は UI を一切出さないサイレントモード。
+      // ブラウザに Google セッションがなければ即座にエラーコールバックが呼ばれる。
+      client.requestAccessToken({ prompt: 'none' });
+    } catch {
+      settle(null);
+    }
+
+    silentRefreshPromiseRef.current = promise;
+    promise.finally(() => {
+      clearTimeout(timeoutId);
+      silentRefreshPromiseRef.current = null;
+    });
+
+    return promise;
+  }, []);
+
+  // サイレント再取得も失敗して完全に再認証が必要になった状態。
+  // userInfo は残して「前回サインイン済みだった」表示を可能にする。
+  const handleSessionExpired = useCallback(async () => {
+    setAccessToken(null);
+    setIsAuthenticated(false);
+    setResults([]);
+    setRecentFiles([]);
+    await clearStoredToken();
+    setError('auth_session_expired');
+  }, []);
+
+  // Drive API 呼び出しを 401/403 自動回復でラップする。
+  // 失敗時は UnauthorizedError を再 throw するので呼び出し元で識別可能。
+  const callWithReauth = useCallback(
+    async <T>(token: string, fn: (t: string) => Promise<T>): Promise<T> => {
+      try {
+        return await fn(token);
+      } catch (err) {
+        if (!(err instanceof UnauthorizedError)) {
+          throw err;
+        }
+        const newToken = await silentRefresh();
+        if (!newToken) {
+          await handleSessionExpired();
+          throw err;
+        }
+        try {
+          return await fn(newToken);
+        } catch (retryErr) {
+          if (retryErr instanceof UnauthorizedError) {
+            await handleSessionExpired();
+          }
+          throw retryErr;
+        }
+      }
+    },
+    [silentRefresh, handleSessionExpired]
+  );
+
   // 検索
   const search = useCallback(async (query: string) => {
     if (!accessToken) {
@@ -426,15 +529,21 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     setError(null);
 
     try {
-      const files = await searchMarkdownFiles(accessToken, query);
+      const files = await callWithReauth(accessToken, (t) =>
+        searchMarkdownFiles(t, query)
+      );
       setResults(files);
     } catch (err) {
+      // UnauthorizedError はセッション切れ扱いで handleSessionExpired が error を設定済み
+      if (err instanceof UnauthorizedError) {
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Search failed');
       console.error('Search error:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [accessToken]);
+  }, [accessToken, callWithReauth]);
 
   // 最近のファイルを取得
   const loadRecentFiles = useCallback(async () => {
@@ -446,15 +555,20 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     setError(null);
 
     try {
-      const files = await listRecentMarkdownFiles(accessToken);
+      const files = await callWithReauth(accessToken, (t) =>
+        listRecentMarkdownFiles(t)
+      );
       setRecentFiles(files);
     } catch (err) {
+      if (err instanceof UnauthorizedError) {
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to load recent files');
       console.error('Load recent files error:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [accessToken]);
+  }, [accessToken, callWithReauth]);
 
   // ファイル内容を取得
   const fetchFileContent = useCallback(
@@ -472,16 +586,18 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
 
       try {
         console.log('[fetchFileContent] API呼び出し開始');
-        const result = await fetchDriveFileContent(
-          accessToken,
-          fileId,
-          signal
+        const result = await callWithReauth(accessToken, (t) =>
+          fetchDriveFileContent(t, fileId, signal)
         );
         console.log('[fetchFileContent] API呼び出し成功, 長さ:', result?.length);
         return result;
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') {
           throw err;
+        }
+        if (err instanceof UnauthorizedError) {
+          // handleSessionExpired が error を設定済み
+          return null;
         }
         console.error('[fetchFileContent] エラー:', err);
         setError(
@@ -490,7 +606,7 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
         return null;
       }
     },
-    [accessToken, isTokenRestored, isAuthenticated]
+    [accessToken, isTokenRestored, isAuthenticated, callWithReauth]
   );
 
   // 検索結果をクリア

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -325,6 +325,7 @@ export const en = {
     popupBlockedPwa: 'Google Sign-in may not work when opened from the Home Screen. Please open MarkDrive in Safari to sign in.',
     thirdPartyCookieHint: 'If you see "Couldn\'t sign you in", go to Settings > Safari and disable "Prevent Cross-Site Tracking".',
     openInSafari: 'Open in Safari',
+    sessionExpired: 'Your Google session has expired. Please sign in again to continue.',
   },
 
   // Drive File Browser (iOS PWA)
@@ -684,6 +685,7 @@ export type Translations = {
     popupBlockedPwa: string;
     thirdPartyCookieHint: string;
     openInSafari: string;
+    sessionExpired: string;
   };
   driveBrowser: {
     title: string;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -327,6 +327,7 @@ export const ja: Translations = {
     popupBlockedPwa: 'ホーム画面から開いた場合、Googleサインインが正常に動作しないことがあります。Safariで直接開いてサインインしてください。',
     thirdPartyCookieHint: '「Googleアカウントにアクセスできません」と表示される場合は、Safariの設定 →「サイト越えトラッキングを防ぐ」をオフにしてください。',
     openInSafari: 'Safariで開く',
+    sessionExpired: 'Googleセッションの有効期限が切れました。続けるには再度サインインしてください。',
   },
 
   // Drive File Browser (iOS PWA)

--- a/src/services/googleDrive.test.ts
+++ b/src/services/googleDrive.test.ts
@@ -10,16 +10,23 @@ import {
   fetchFileContent,
   fetchFileInfo,
   isMarkdownFile,
+  UnauthorizedError,
 } from './googleDrive';
 import type { DriveFile } from '../types/googleDrive';
 
 // Mock fetch
 const originalFetch = globalThis.fetch;
 
-function mockFetch(response: unknown, ok = true, statusText = 'OK') {
+function mockFetch(
+  response: unknown,
+  ok = true,
+  statusText = 'OK',
+  status = ok ? 200 : 500
+) {
   globalThis.fetch = vi.fn(async () =>
     ({
       ok,
+      status,
       statusText,
       json: async () => response,
       text: async () => (typeof response === 'string' ? response : JSON.stringify(response)),
@@ -195,6 +202,54 @@ describe('fetchFileInfo', () => {
     });
     const info = await fetchFileInfo('test-token', 'file-id');
     expect(info).toBeNull();
+  });
+});
+
+describe('UnauthorizedError handling', () => {
+  it('searchMarkdownFiles throws UnauthorizedError on 401', async () => {
+    mockFetch({}, false, 'Unauthorized', 401);
+    await expect(searchMarkdownFiles('stale-token', 'q')).rejects.toBeInstanceOf(
+      UnauthorizedError
+    );
+  });
+
+  it('searchMarkdownFiles throws UnauthorizedError on 403', async () => {
+    mockFetch({}, false, 'Forbidden', 403);
+    await expect(searchMarkdownFiles('stale-token', 'q')).rejects.toBeInstanceOf(
+      UnauthorizedError
+    );
+  });
+
+  it('listRecentMarkdownFiles throws UnauthorizedError on 401', async () => {
+    mockFetch({}, false, 'Unauthorized', 401);
+    await expect(listRecentMarkdownFiles('stale-token')).rejects.toBeInstanceOf(
+      UnauthorizedError
+    );
+  });
+
+  it('fetchFileContent throws UnauthorizedError on 401', async () => {
+    mockFetch('', false, 'Unauthorized', 401);
+    await expect(
+      fetchFileContent('stale-token', 'file-id')
+    ).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+
+  it('UnauthorizedError carries status code', async () => {
+    mockFetch({}, false, 'Forbidden', 403);
+    try {
+      await searchMarkdownFiles('stale-token', 'q');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnauthorizedError);
+      expect((err as UnauthorizedError).status).toBe(403);
+    }
+  });
+
+  it('non-auth errors stay as plain Error', async () => {
+    mockFetch({}, false, 'Internal Server Error', 500);
+    await expect(searchMarkdownFiles('token', 'q')).rejects.not.toBeInstanceOf(
+      UnauthorizedError
+    );
   });
 });
 

--- a/src/services/googleDrive.ts
+++ b/src/services/googleDrive.ts
@@ -15,6 +15,23 @@ const MARKDOWN_MIME_TYPES = ['text/markdown', 'text/x-markdown', 'text/plain'];
 const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
 
 /**
+ * 認証失敗（アクセストークン失効・権限不足など）を示すエラー。
+ * 呼び出し元でサイレント再取得のトリガーに利用する。
+ */
+export class UnauthorizedError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`Unauthorized (status ${status})`);
+    this.name = 'UnauthorizedError';
+    this.status = status;
+  }
+}
+
+function isAuthFailure(response: Response): boolean {
+  return response.status === 401 || response.status === 403;
+}
+
+/**
  * 検索クエリをサニタイズ（シングルクォートをエスケープ）
  */
 function sanitizeQuery(query: string): string {
@@ -81,6 +98,9 @@ export async function searchMarkdownFiles(
   );
 
   if (!response.ok) {
+    if (isAuthFailure(response)) {
+      throw new UnauthorizedError(response.status);
+    }
     throw new Error(`Search failed: ${response.statusText}`);
   }
 
@@ -110,6 +130,9 @@ export async function fetchFileContent(
   });
 
   if (!response.ok) {
+    if (isAuthFailure(response)) {
+      throw new UnauthorizedError(response.status);
+    }
     throw new Error(`Failed to fetch file: ${response.statusText}`);
   }
 
@@ -175,6 +198,9 @@ export async function listRecentMarkdownFiles(
   );
 
   if (!response.ok) {
+    if (isAuthFailure(response)) {
+      throw new UnauthorizedError(response.status);
+    }
     throw new Error(`Failed to list files: ${response.statusText}`);
   }
 


### PR DESCRIPTION
## Summary

- localStorage に access_token は残っているのに Drive API が 401/403 を返した場合でも、手動ログアウトしか回復手段がなかった問題を解消
- GIS の `prompt: 'none'` でブラウザ内の Google セッションから無 UI で access_token を再発行する `silentRefresh` を追加
- サイレント再取得が失敗したときだけ「セッション切れ」オーバーレイを明示的に表示し、既存の `onRetry={authenticate}` 導線にそのまま乗せる

## Changes

- `services/googleDrive.ts`: 401/403 を `UnauthorizedError` で識別可能に(他のステータスは従来どおりの `Error`)
- `hooks/useGoogleAuth.ts`:
  - `silentRefresh()` を追加(同時呼び出しは 1 本化、10 秒のセーフティタイムアウト付き)
  - `callWithReauth()` が 401 を捕まえ → サイレント再取得 → 1 回だけリトライ → それでも失敗したら `handleSessionExpired()` で token 破棄 + `auth_session_expired` を表示
  - `search` / `loadRecentFiles` / `fetchFileContent` を `callWithReauth` 経由に差し替え
- `OAuthOverlay.tsx` + i18n (`en` / `ja`): `auth_session_expired` → `sessionExpired` のマッピングを追加

## Design Notes

- localStorage の保存形式は据え置き(GIS implicit flow では refresh_token が発行されず、これ以上安全な保管場所も無い)。改善の効きどころは保持方法ではなく失効検知と回復動線にあるため
- サイレント再取得は Safari ITP 等で失敗することはあるが、その場合も「明示的な再サインイン UI に落ちる」だけで自動ログアウト袋小路は回避される
- `userInfo` はセッション切れ後も保持し、将来的に「前回サインインしていたアカウント」を UI に出せるようにしておく(今回の PR では追加表示はしない)

## Test plan

- [x] `bun run test` (全 658 件パス)
- [x] `bunx tsc --noEmit`
- [x] 追加テスト:
  - [x] `googleDrive.test.ts`: 401/403 → `UnauthorizedError`、500 → `Error`
  - [x] `useGoogleAuth.test.ts`: 401 → サイレント再取得成功 → 透過的リトライ
  - [x] `useGoogleAuth.test.ts`: サイレント再取得失敗 → `auth_session_expired` + token 破棄
  - [x] `useGoogleAuth.test.ts`: 非認証エラーはリトライしない
  - [x] `useGoogleAuth.test.ts`: `search` / `loadRecentFiles` / `fetchFileContent` 全てで回復
  - [x] `OAuthOverlay.test.tsx`: `auth_session_expired` 時に Retry ボタン表示 + ヒントなし
- [ ] 手動確認: トークンを localStorage で改ざんして 401 を発生させ、再サインインなしで動作継続できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)