### PR TITLE
fix: iOS Safari でも Google Picker 代替のアプリ内ブラウザを使用

### DIFF
--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -1849,7 +1849,7 @@ describe('useGoogleAuth', () => {
       window.gapi.client = originalClient;
     });
 
-    it('should show DriveFileBrowser in iOS PWA mode instead of Picker', async () => {
+    it('should show DriveFileBrowser on iOS (PWA) instead of Picker', async () => {
       authenticateHook();
 
       // Simulate iOS + standalone (PWA) environment
@@ -1938,6 +1938,55 @@ describe('useGoogleAuth', () => {
 
       const pickerResult = await pickerPromise!;
       expect(pickerResult).toBeNull();
+      expect(result.current.driveFileBrowserProps).toBeNull();
+
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64)',
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('should show DriveFileBrowser on iOS Safari (non-PWA) instead of Picker', async () => {
+      authenticateHook();
+
+      // Simulate iOS Safari (not standalone)
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X)',
+        writable: true,
+        configurable: true,
+      });
+      window.matchMedia = vi.fn((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+
+      const { result } = renderHook(() => useGoogleAuth());
+      await waitForInit();
+
+      expect(result.current.driveFileBrowserProps).toBeNull();
+
+      let pickerPromise: Promise<any>;
+      act(() => {
+        pickerPromise = result.current.openDrivePicker();
+      });
+
+      // DriveFileBrowser が Picker の代わりに使われる
+      expect(result.current.driveFileBrowserProps).not.toBeNull();
+      expect(result.current.driveFileBrowserProps!.accessToken).toBe('valid-token');
+
+      await act(async () => {
+        result.current.driveFileBrowserProps!.onSelect({ id: 'file-2', name: 'safari.md' });
+      });
+
+      const pickerResult = await pickerPromise!;
+      expect(pickerResult).toEqual({ id: 'file-2', name: 'safari.md' });
       expect(result.current.driveFileBrowserProps).toBeNull();
 
       Object.defineProperty(navigator, 'userAgent', {

--- a/src/hooks/useGoogleAuth.ts
+++ b/src/hooks/useGoogleAuth.ts
@@ -15,7 +15,7 @@ import {
 } from '../services/googleDrive';
 import { storage } from '../services/storage';
 import { trackEvent } from '../utils/analytics';
-import { isIOS, isStandaloneMode, isIosPwa } from '../utils/platform';
+import { isIOS, isStandaloneMode } from '../utils/platform';
 import type { DriveFileBrowserProps } from '../components/ui/DriveFileBrowser';
 
 // 環境変数から設定を取得
@@ -624,8 +624,10 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
         return;
       }
 
-      // iOS PWA モードでは Google Picker が動作しないため、アプリ内ファイルブラウザを表示
-      if (isIosPwa()) {
+      // iOS Safari / PWA では ITP により Google Picker の iframe が Google の
+      // Cookie にアクセスできず "Can't access your Google Account" エラーになる。
+      // そのためアプリ内ファイルブラウザで代替する。
+      if (isIOS()) {
         setDriveFileBrowserState({
           accessToken,
           onSelect: (result) => {


### PR DESCRIPTION
iOS Safari では ITP により Google Picker の iframe が Google の
Cookie にアクセスできず「Can't access your Google Account」エラー
になる。これまで iOS PWA のみで有効だった DriveFileBrowser を
iOS デバイス全般で使うようにし、通常の iOS Safari でも同じ問題が
起きないようにする。

https://claude.ai/code/session_011h3EAkBLS5tPYeguaExA3G