### PR TITLE
fix: OAuth スコープを drive.readonly に戻してスマホで全ファイルを検索可能に

### DIFF
--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -138,7 +138,7 @@ describe('useGoogleAuth', () => {
     storageMock = createLocalStorageMock();
     Object.defineProperty(window, 'localStorage', { value: storageMock, writable: true });
     // Pre-set scope version so token restoration doesn't get cleared
-    storageMock.setItem('googleDriveScopeVersion', '3');
+    storageMock.setItem('googleDriveScopeVersion', '4');
     setupEnvVars();
     setupGoogleApis();
     stubScriptLoading();
@@ -180,7 +180,7 @@ describe('useGoogleAuth', () => {
     it('should restore valid token from storage', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'stored-token-value';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -196,7 +196,7 @@ describe('useGoogleAuth', () => {
     it('should not restore expired token', async () => {
       const pastExpiry = String(Date.now() - 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'old-token';
         if (key === 'googleDriveTokenExpiry') return pastExpiry;
         return null;
@@ -212,7 +212,7 @@ describe('useGoogleAuth', () => {
     it('should not restore token expiring within 5 minutes', async () => {
       const nearExpiry = String(Date.now() + 3 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'near-expired-token';
         if (key === 'googleDriveTokenExpiry') return nearExpiry;
         return null;
@@ -843,7 +843,7 @@ describe('useGoogleAuth', () => {
     it('should clear results for empty query', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -863,7 +863,7 @@ describe('useGoogleAuth', () => {
     it('should return search results when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -886,7 +886,7 @@ describe('useGoogleAuth', () => {
 
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -909,7 +909,7 @@ describe('useGoogleAuth', () => {
     it('should load recent files when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -945,7 +945,7 @@ describe('useGoogleAuth', () => {
     it('should fetch file content when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -982,7 +982,7 @@ describe('useGoogleAuth', () => {
 
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1008,7 +1008,7 @@ describe('useGoogleAuth', () => {
     }) {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'stale-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1332,7 +1332,7 @@ describe('useGoogleAuth', () => {
     it('falls back to session expired when tokenClient is not initialized', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'stale-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1500,7 +1500,7 @@ describe('useGoogleAuth', () => {
     it('should clear all state on logout', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1526,7 +1526,7 @@ describe('useGoogleAuth', () => {
     it('should revoke token via Google API', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1548,7 +1548,7 @@ describe('useGoogleAuth', () => {
     it('should clear stored token from localStorage', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1600,7 +1600,7 @@ describe('useGoogleAuth', () => {
     function authenticateHook() {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '3';
+        if (key === 'googleDriveScopeVersion') return '4';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;

--- a/src/hooks/useGoogleAuth.ts
+++ b/src/hooks/useGoogleAuth.ts
@@ -23,11 +23,11 @@ const API_KEY = import.meta.env.VITE_GOOGLE_API_KEY || '';
 const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
 const APP_ID = import.meta.env.VITE_GOOGLE_APP_ID || '';
 
-// Google API のスコープ（Picker で選択したファイルのみアクセス可能 + Drive「アプリで開く」対応）
-const SCOPES = 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.install';
+// Google API のスコープ（読み取り専用 + Drive「アプリで開く」対応）
+const SCOPES = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.install';
 
 // スコープバージョン（スコープ変更時にインクリメントして旧トークンを無効化）
-const SCOPE_VERSION = '3'; // v1: drive.readonly → v2: drive.file → v3: +drive.install
+const SCOPE_VERSION = '4'; // v1: drive.readonly → v2: drive.file → v3: +drive.install → v4: drive.readonly に戻す
 
 // ストレージのキー
 const TOKEN_KEY = 'googleDriveAccessToken';


### PR DESCRIPTION
## 概要

OAuth スコープを `drive.file` から `drive.readonly` に戻し、スマホ版で Drive 内の全 Markdown ファイルが検索・一覧表示できるようにする。

## 背景

PR #163 で iOS PWA 向けにアプリ内 `DriveFileBrowser` を導入、PR #167 で iOS Safari 全般に拡張したが、**スマホで「最近 Drive に追加したファイル」が一覧に出てこない** 問題が残っていた。

調査の結果、原因は OAuth スコープが `drive.file` だったこと:

- `drive.file` は **「アプリが開いた／作ったファイル」しかアクセスできない**
- PC は Google Picker (Google ホストの UI) が Drive 全体を表示でき、選択したファイルだけ `drive.file` 経由でアプリに渡る仕組みなので問題なし
- スマホ版 `DriveFileBrowser` はアプリが直接 `files.list` を叩くので、`drive.file` の制約をもろに受け、新規追加ファイルが見えない

## 変更内容

- `SCOPES` を `drive.file` → `drive.readonly` に変更 (`drive.install` は維持)
- `SCOPE_VERSION` を `3` → `4` に上げ、既存ユーザーのトークンを無効化して再認証を促す
- 対応するテスト 16 箇所を更新

## 整合性のメリット

プライバシーポリシー (`i18n/locales/ja.ts:368`, `en.ts:366`) と利用規約には **元々 `drive.readonly` と明記されていた** が、実装が `drive.file` と乖離していた。今回の変更で規約と実装が一致する。

## 書き込み権限が不要な根拠

`useMarkdownEditor.ts:62` の `save()` は File System Access API でローカル保存するか、ダウンロードフォールバックのみ。Drive への書き戻しは一切行っていない。

## OAuth Verification

Google Cloud Console で `drive.readonly` は既に検証済み (過去 v1 で使用していたため)。

## Test plan

- [x] `bunx vitest run` で全 667 テスト通過
- [x] `bun run build` で型チェック + ビルド成功
- [ ] デプロイ後、既存ユーザーは初回アクセスで再認証画面が出ることを確認
- [ ] スマホ Safari で Drive に新規追加したファイルが `DriveFileBrowser` に表示されることを確認
- [ ] PC で Google Picker 経由のファイル選択が引き続き動作することを確認

https://claude.ai/code/session_011h3EAkBLS5tPYeguaExA3G

---
_Generated by [Claude Code](https://claude.ai/code/session_011h3EAkBLS5tPYeguaExA3G)_