### PR TITLE
Revert #168: OAuth スコープを drive.file に戻す

### DIFF
--- a/src/hooks/useGoogleAuth.test.ts
+++ b/src/hooks/useGoogleAuth.test.ts
@@ -138,7 +138,7 @@ describe('useGoogleAuth', () => {
     storageMock = createLocalStorageMock();
     Object.defineProperty(window, 'localStorage', { value: storageMock, writable: true });
     // Pre-set scope version so token restoration doesn't get cleared
-    storageMock.setItem('googleDriveScopeVersion', '4');
+    storageMock.setItem('googleDriveScopeVersion', '3');
     setupEnvVars();
     setupGoogleApis();
     stubScriptLoading();
@@ -180,7 +180,7 @@ describe('useGoogleAuth', () => {
     it('should restore valid token from storage', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'stored-token-value';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -196,7 +196,7 @@ describe('useGoogleAuth', () => {
     it('should not restore expired token', async () => {
       const pastExpiry = String(Date.now() - 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'old-token';
         if (key === 'googleDriveTokenExpiry') return pastExpiry;
         return null;
@@ -212,7 +212,7 @@ describe('useGoogleAuth', () => {
     it('should not restore token expiring within 5 minutes', async () => {
       const nearExpiry = String(Date.now() + 3 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'near-expired-token';
         if (key === 'googleDriveTokenExpiry') return nearExpiry;
         return null;
@@ -843,7 +843,7 @@ describe('useGoogleAuth', () => {
     it('should clear results for empty query', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -863,7 +863,7 @@ describe('useGoogleAuth', () => {
     it('should return search results when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -886,7 +886,7 @@ describe('useGoogleAuth', () => {
 
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -909,7 +909,7 @@ describe('useGoogleAuth', () => {
     it('should load recent files when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -945,7 +945,7 @@ describe('useGoogleAuth', () => {
     it('should fetch file content when authenticated', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -982,7 +982,7 @@ describe('useGoogleAuth', () => {
 
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1008,7 +1008,7 @@ describe('useGoogleAuth', () => {
     }) {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'stale-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1332,7 +1332,7 @@ describe('useGoogleAuth', () => {
     it('falls back to session expired when tokenClient is not initialized', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'stale-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1500,7 +1500,7 @@ describe('useGoogleAuth', () => {
     it('should clear all state on logout', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1526,7 +1526,7 @@ describe('useGoogleAuth', () => {
     it('should revoke token via Google API', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1548,7 +1548,7 @@ describe('useGoogleAuth', () => {
     it('should clear stored token from localStorage', async () => {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;
@@ -1600,7 +1600,7 @@ describe('useGoogleAuth', () => {
     function authenticateHook() {
       const futureExpiry = String(Date.now() + 60 * 60 * 1000);
       storageMock.getItem.mockImplementation((key: string) => {
-        if (key === 'googleDriveScopeVersion') return '4';
+        if (key === 'googleDriveScopeVersion') return '3';
         if (key === 'googleDriveAccessToken') return 'valid-token';
         if (key === 'googleDriveTokenExpiry') return futureExpiry;
         return null;

--- a/src/hooks/useGoogleAuth.ts
+++ b/src/hooks/useGoogleAuth.ts
@@ -23,11 +23,11 @@ const API_KEY = import.meta.env.VITE_GOOGLE_API_KEY || '';
 const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
 const APP_ID = import.meta.env.VITE_GOOGLE_APP_ID || '';
 
-// Google API のスコープ（読み取り専用 + Drive「アプリで開く」対応）
-const SCOPES = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.install';
+// Google API のスコープ（Picker で選択したファイルのみアクセス可能 + Drive「アプリで開く」対応）
+const SCOPES = 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.install';
 
 // スコープバージョン（スコープ変更時にインクリメントして旧トークンを無効化）
-const SCOPE_VERSION = '4'; // v1: drive.readonly → v2: drive.file → v3: +drive.install → v4: drive.readonly に戻す
+const SCOPE_VERSION = '3'; // v1: drive.readonly → v2: drive.file → v3: +drive.install
 
 // ストレージのキー
 const TOKEN_KEY = 'googleDriveAccessToken';


### PR DESCRIPTION
## 概要

PR #168 をリバートし、OAuth スコープを `drive.readonly` → `drive.file` に戻す。

## 経緯

#168 でスマホ版 `DriveFileBrowser` で新規追加ファイルが見えない問題を `drive.readonly` 化で解決したが、ユーザー判断で **より狭いスコープ (`drive.file`) に戻す** ことに。

## トレードオフ (既知事項)

- ✅ アプリの権限要求が最小限 (アプリで開いた／作ったファイルだけ)
- ❌ **スマホで Drive に新規追加したファイルが `DriveFileBrowser` に表示されない問題が再発** する
- ❌ プライバシーポリシー (`i18n/locales/ja.ts:368`, `en.ts:366`) と実装が再度乖離する (規約には `drive.readonly` と記載)

## 変更内容

`f9f6a87` のリバートのみ。

- `SCOPES`: `drive.readonly` → `drive.file`
- `SCOPE_VERSION`: `4` → `3`
- テストの SCOPE_VERSION 値も `'4'` → `'3'`

## Test plan

- [x] `bunx vitest run` で 59 件通過
- [ ] デプロイ後、既存ユーザー (今 v4 トークンを持っている) は SCOPE_VERSION ダウングレード扱いになり再認証が必要になることを確認

https://claude.ai/code/session_011h3EAkBLS5tPYeguaExA3G

---
_Generated by [Claude Code](https://claude.ai/code/session_011h3EAkBLS5tPYeguaExA3G)_